### PR TITLE
feat: add authMethod to kratix chart

### DIFF
--- a/kratix/templates/statestores.yaml
+++ b/kratix/templates/statestores.yaml
@@ -12,7 +12,11 @@ spec:
   {{- if eq .kind "GitStateStore" }}
   url: {{ .url }}
   branch: {{ .branch }}
-  {{- else }}
+  {{- if eq .authMethod "ssh" }}
+  authMethod: ssh
+  {{- else}}
+  authMethod: basicAuth
+  {{- end }}
   bucketName: {{ .bucket }}
   endpoint: {{ .endpoint }}
   insecure: {{ .insecure }}


### PR DESCRIPTION
This PR will add the possibility to define the authMethod for the Kratix helm chart. If no value is defined, the value is automatically set to basicAuth. With my change, this will also be explicit visible.