### PR TITLE
feat: add authMethod to kratix chart

### DIFF
--- a/kratix/templates/statestores.yaml
+++ b/kratix/templates/statestores.yaml
@@ -12,7 +12,11 @@ spec:
   {{- if eq .kind "GitStateStore" }}
   url: {{ .url }}
   branch: {{ .branch }}
-  {{- else }}
+  {{- if eq .authMethod "ssh" }}
+  authMethod: ssh
+  {{- else}}
+  authMethod: basicAuth
+  {{- end }}
   bucketName: {{ .bucket }}
   endpoint: {{ .endpoint }}
   insecure: {{ .insecure }}

--- a/kratix/templates/statestores.yaml
+++ b/kratix/templates/statestores.yaml
@@ -14,8 +14,6 @@ spec:
   branch: {{ .branch }}
   {{- if eq .authMethod "ssh" }}
   authMethod: ssh
-  {{- else}}
-  authMethod: basicAuth
   {{- end }}
   bucketName: {{ .bucket }}
   endpoint: {{ .endpoint }}


### PR DESCRIPTION
I seem to have messed something up due to the fact that my email address was missing from the commit. This meant that the CLA could not accept correctly. Hopefully everything should be fine now.

Original PR:
This PR will add the possibility to define the authMethod for the Kratix helm chart. If no value is defined, the value is automatically set to basicAuth. With my change, this will also be explicit visible.