### PR TITLE
fix: template ske deployment version correctly

### DIFF
--- a/ske-operator/templates/ske-deployment.yaml
+++ b/ske-operator/templates/ske-deployment.yaml
@@ -6,6 +6,6 @@ kind: Kratix
 metadata:
   name: kratix
 spec:
-  version: {{ .version | default "latest" }}
+  version: {{ .Values.skeDeployment.version | default "latest" }}
 {{- end -}}
 {{- end -}}


### PR DESCRIPTION
# Context

`.version` will get the chart version which is set in https://github.com/syntasso/helm-charts/blob/main/ske-operator/Chart.yaml#L5

[`values.skeDeployment.version`](https://github.com/syntasso/helm-charts/blob/main/ske-operator/values.yaml#L45) is what we should use for `spec.version` for `Kratix`: 