### PR TITLE
Install operator at a fixed version

### DIFF
--- a/scripts/update-ske-operator
+++ b/scripts/update-ske-operator
@@ -34,6 +34,3 @@ mv $root/ske-operator/manifests.yaml ${CHART_DISTRIBUTION}
 current_chart_version="$(yq -r '.version' ske-operator/Chart.yaml)"
 export new_chart_version="$(echo $current_chart_version | awk -F. '{$2 = $2 + 1;} 1' | sed 's/ /./g')"
 yq -i '.appVersion = strenv(latest_version) | .version = env(new_chart_version)' ske-operator/Chart.yaml
-
-# bump the default image version in the values.yaml
-yq -i '.imageRegistry.skeOperatorImage.tag = strenv(latest_version)' ske-operator/values.yaml

--- a/ske-operator/kustomization.yaml
+++ b/ske-operator/kustomization.yaml
@@ -3,7 +3,7 @@ resources:
 images:
 - name: ghcr.io/syntasso/ske-operator
   newName: "{{ .Values.imageRegistry.host }}/{{ .Values.imageRegistry.skeOperatorImage.name }}"
-  newTag: "{{ .Values.imageRegistry.skeOperatorImage.tag }}"
+  newTag: "{{ .Chart.AppVersion }}"
 patches:
   - target:
       kind: Deployment

--- a/ske-operator/templates/operator-config.yaml
+++ b/ske-operator/templates/operator-config.yaml
@@ -23,7 +23,7 @@ data:
         {{- with .Values.releaseStorage.bucket }}
         name: {{ .name }}
         endpoint: {{ .endpoint }}
-        region: {{ .rergion }}
+        region: {{ .region }}
         {{- if .secret }}
         secretName: {{ .secret.name }}
         {{- end }}

--- a/ske-operator/templates/ske-operator-distribution.yaml
+++ b/ske-operator/templates/ske-operator-distribution.yaml
@@ -370,7 +370,7 @@ spec:
         command:
         - /manager
         image: '{{ .Values.imageRegistry.host }}/{{ .Values.imageRegistry.skeOperatorImage.name
-          }}:{{ .Values.imageRegistry.skeOperatorImage.tag }}'
+          }}:{{ .Chart.AppVersion }}'
         livenessProbe:
           httpGet:
             path: /healthz

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -16,8 +16,6 @@ imageRegistry:
   skeOperatorImage:
     # The name of the SKE operator use. Update this if you are using a custom image name for the operator
     name: "syntasso/ske-operator"
-    # The tag of the SKE Operator image
-    tag: "v0.3.1"
   skePlatformImage:
     # The name of the SKE Platform image
     name: "syntasso/ske-platform"


### PR DESCRIPTION
## Expected behaviour for acceptance

**Default with no attempt to set the `tag`**

Context: A `Chart.yaml` where appVersion = v0.3.1 (reflecting the Operator version). `imageRegistry.tag` is not set.

_Setup cluster with cert-manager_
```
// from helm-charts/ske-operator

kind create cluster

kubectl apply --filename https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml
namespace/cert-manager
```

_Update `values.yaml`_

```
skeLicense: "a-real-token"
```

_Install Chart with `values.yaml`_
```
helm install ske-operator . \
  --namespace kratix-platform-system \
  --create-namespace \
  --values values.yaml
```

_Check operator version_
```
helm list --all-namespaces

-> ske-operator	kratix-platform-system	1       	2024-10-16 12:31:55.732419 +0100 BST	deployed	ske-operator-0.17.0	v0.3.1
```

SKE Operator version should match the `appVersion` in `Chart.yaml`

```
k get pods --selector=control-plane=ske-operator -A -o yaml | yq '.items[0].spec.containers[0].image'

-> ghcr.io/syntasso/ske-operator:v0.3.1
```

Image tag should match the `appVersion` in `Chart.yaml`

**Attempting to set the deprecated `tag`**

Context: A `Chart.yaml` where appVersion = v0.3.1 (reflecting the Operator version). `imageRegistry.tag` is set to `v0.2.0`.

tl;dr same behaviour with the tag ignored

_Setup cluster with cert-manager_
```
// from helm-charts/ske-operator

kind create cluster

kubectl apply --filename https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml
namespace/cert-manager
```

_Update `values.yaml`_

```
skeLicense: "a-real-token"
```

_Install Chart with `values.yaml`_
```
helm install ske-operator . \
  --namespace kratix-platform-system \
  --create-namespace \
  --values values.yaml
```

_Check operator version_
```
helm list --all-namespaces

-> ske-operator	kratix-platform-system	1       	2024-10-16 12:31:55.732419 +0100 BST	deployed	ske-operator-0.17.0	v0.3.1
```

SKE Operator version should match the `appVersion` in `Chart.yaml`

```
k get pods --selector=control-plane=ske-operator -A -o yaml | yq '.items[0].spec.containers[0].image'

-> ghcr.io/syntasso/ske-operator:v0.3.1
```

Image tag should match the `appVersion` in `Chart.yaml`