### PR TITLE
feat: allow additional resources for ske-operator

### DIFF
--- a/ske-operator/templates/additional-resources.yaml
+++ b/ske-operator/templates/additional-resources.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.additionalResources }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/ske-operator/templates/post-install-job.yaml
+++ b/ske-operator/templates/post-install-job.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.skeDeployment.enabled }}
+{{- if .Values.skeDeployment.additionalResources }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-additional-resources
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "3"
+spec:
+  template:
+    spec:
+      serviceAccountName: ske-operator-controller-manager
+      restartPolicy: Never
+      containers:
+        - name: create-resources
+          image: ghcr.io/syntasso/kratix-pipeline-utility:v0.0.1
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -exu
+              kubectl wait --for=condition=KratixDeploymentReady kratixes/kratix --timeout=300s
+              {{ range .Values.skeDeployment.additionalResources }}
+              cat <<EOF | kubectl apply -f -
+              {{ . | toYaml | indent 14 | trim }}
+              EOF
+              {{ end }}
+{{- end -}}
+{{- end -}}

--- a/ske-operator/templates/ske-deployment.yaml
+++ b/ske-operator/templates/ske-deployment.yaml
@@ -6,6 +6,7 @@ metadata:
   name: kratix
   annotations:
     helm.sh/hook: post-install
+    "helm.sh/hook-weight": "1"
 spec:
   version: {{ .version | default "latest" }}
   tlsConfig:

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -76,4 +76,16 @@ skeDeployment:
     # webhookCACert:
     # webhookTLSKey:
     # webhookTLSCert:
-
+  additionalResources: []
+  # Example
+  # - kind: Destination
+  #   apiVersion: platform.kratix.io/v1alpha1
+  #   name: worker-1
+  #   labels:
+  #     env: dev
+  #   stateStoreRef:
+  #     name: default
+  #     kind: GitStateStore
+  #   strictMatchLabels: false
+additionalResources: []
+# Any additional k8s resources, such as Secrets, Configmaps

--- a/tests/assets/values-with-certmanager.yaml
+++ b/tests/assets/values-with-certmanager.yaml
@@ -13,3 +13,33 @@ skeDeployment:
   tlsConfig:
     certManager:
       disabled: false
+  additionalResources:
+    - kind: GitStateStore
+      apiVersion: platform.kratix.io/v1alpha1
+      metadata:
+        name: default
+      spec:
+        secretRef:
+          name: git-credentials
+          namespace: default
+        url: https://172.18.0.2:31333/gitea_admin/kratix
+        branch: main
+    - apiVersion: platform.kratix.io/v1alpha1
+      kind: Destination
+      metadata:
+        name: worker-1
+        labels:
+          environment: dev
+      spec:
+        stateStoreRef:
+          name: default
+          kind: GitStateStore
+additionalResources:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: git-credentials
+      namespace: default
+    stringData:
+      username: wow
+      password: what=_=lookingat

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -20,7 +20,7 @@ var (
 )
 
 var _ = Describe("ske-operator helm chart", func() {
-	Context("when global.skeOperator.tlsConfig.certManager.disabled=false", func() {
+	When("global.skeOperator.tlsConfig.certManager.disabled=false", func() {
 		BeforeEach(func() {
 			run("kubectl", context, "apply", "-f=https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml")
 			run("kubectl", context, "wait", "crd/certificates.cert-manager.io", "--for=condition=established", "--timeout=60s")
@@ -43,13 +43,19 @@ var _ = Describe("ske-operator helm chart", func() {
 			run("kubectl", context, "get", "certificates", "ske-operator-serving-cert", "-n=kratix-platform-system")
 			run("kubectl", context, "get", "issuer", "ske-operator-selfsigned-issuer", "-n=kratix-platform-system")
 
+			By("deploying kratix")
 			//if the Kratix got created successfully by helm install, this means the
 			//webhook was running successfully
 			run("kubectl", context, "get", "kratixes", "kratix")
+
+			By("creating any additional resources provided in values file")
+			run("kubectl", context, "get", "secrets", "git-credentials", "-n=default")
+			run("kubectl", context, "get", "gitstatestores", "default")
+			run("kubectl", context, "get", "destinations", "worker-1")
 		})
 	})
 
-	Context("when global.skeOperator.tlsConfig.certManager.disabled=true, and certs are provided", func() {
+	When("global.skeOperator.tlsConfig.certManager.disabled=true, and certs are provided", func() {
 		BeforeEach(func() {
 			//double check cert-manager is not installed
 			crds := run("kubectl", context, "get", "crds")
@@ -104,7 +110,7 @@ func r(g Gomega, t time.Duration, args ...string) string {
 	command.Env = os.Environ()
 	session, err := gexec.Start(command, GinkgoWriter, GinkgoWriter)
 	fmt.Fprintf(GinkgoWriter, "Running: %s %s\n", firstArg, strings.Join(remainingArgs, " "))
-	g.ExpectWithOffset(1, err).ShouldNot(HaveOccurred())
-	g.EventuallyWithOffset(1, session, t, interval).Should(gexec.Exit(0))
+	g.ExpectWithOffset(2, err).ShouldNot(HaveOccurred())
+	g.EventuallyWithOffset(2, session, t, interval).Should(gexec.Exit(0))
 	return string(session.Out.Contents())
 }


### PR DESCRIPTION
# Context

relates to https://github.com/syntasso/enterprise-kratix/issues/144

Users can now provide additional kratix resources such as destinations and state stores, as well as other k8s resources when installing the ske-operator chart. For example:
```
# inside of a values file

skeDeployment:
  additionalResources:
    - kind: GitStateStore
      apiVersion: platform.kratix.io/v1alpha1
      metadata:
        name: default
      spec:
        secretRef:
          name: test
          namespace: default
        url: https://172.18.0.2:31333/gitea_admin/kratix
        branch: main
additionalResources:
  - apiVersion: v1
     kind: Secret
     metadata:
       name: test
     data:
       username: test
       password: whatyoulookingat
``` 

Additional resources under `skeDeployment` will be applied via a post install/upgrade job. `additionalResources` at the top level will be applied as the rest of the template, assuming they are resources already available to create and update at the time of installation.

There will be a follow up PR to move kratix values files taking in additional resources only, instead of separate lists of state store and destinations.
