### PR TITLE
chore: use additionalResources in kratix chart

### DIFF
--- a/kratix/README.md
+++ b/kratix/README.md
@@ -24,32 +24,37 @@ configure a worker destination and a [BucketStateStore](https://kratix.io/docs/m
 at installation time you could provide the following `values.yaml` file:
 
 ```yaml
-stateStores:
+additionalResources:
 - kind: BucketStateStore
-  name: default
-  namespace: default
-  secretRef:
-    name: minio-credentials
-    # Optional, omit `values` field when the secret creation is managed externally
-    values:
-      accesskey: bWluaW9hZG1pbg==
-      secretkey: bWluaW9hZG1pbg==
-  insecure: true
-  endpoint: minio.kratix-platform-system.svc.cluster.local
-  bucket: kratix
-
-destinations:
-- name: worker-1
-  namespace: default
-  labels:
-    env: dev
-  path: ""
-  filepath:
-    mode: nestedByMetadata
-  stateStoreRef:
+  apiVersion: platform.kratix.io/v1alpha1
+  metadata:
     name: default
-    kind: BucketStateStore
-  strictMatchLabels: false
+  spec:
+    endpoint: minio.kratix-platform-system.svc.cluster.local
+    insecure: true
+    bucketName: kratix
+    authMethod: accessKey
+    secretRef:
+      name: minio-credentials
+      namespace: default
+- kind: Destination
+  apiVersion: platform.kratix.io/v1alpha1
+  metadata:
+    name: worker-1
+    labels:
+      environment: dev
+  spec:
+    stateStoreRef:
+      name: default
+      kind: BucketStateStore
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: minio-credentials
+    namespace: default
+  type: Opaque
+  data:
+...
 ```
 
 See [the values file for more example configuration](./values.yaml). To pass the values file

--- a/kratix/templates/destinations.yaml
+++ b/kratix/templates/destinations.yaml
@@ -1,4 +1,4 @@
-
+# [DEPRECATED] Use additionalResources instead
 {{- range .Values.destinations }}
 ---
 apiVersion: platform.kratix.io/v1alpha1

--- a/kratix/templates/statestores.yaml
+++ b/kratix/templates/statestores.yaml
@@ -1,3 +1,4 @@
+# [DEPRECATED] Use additionalResources instead
 {{- range .Values.stateStores }}
 ---
 apiVersion: platform.kratix.io/v1alpha1

--- a/kratix/values.yaml
+++ b/kratix/values.yaml
@@ -2,49 +2,52 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-stateStores: []
-# Examples
-# - kind: GitStateStore
-#   name: default
-#   path: ""
-#   secretRef:
-#     name: git-creds
-#     values:
-#       username: Zm9vCg==
-#       password: Zm9vCg==
-#   url: https://github.com/kratix/kratix-repo
-#   branch: main
-# - kind: BucketStateStore
-#   name: default
-#   path: ""
-#   secretRef:
-#     name: already-created-s3-creds
-#   insecure: false
-#   endpoint: s3.aws.com
-#   bucket: kraix-platform
+# [DEPRECATED] Use additionalResources instead
+stateStores:
+  - kind: BucketStateStore
+    name: default
+    namespace: default
+    secretRef:
+      name: minio-credentials
+      # Optional, omit `values` field when the secret creation is managed externally
+      values:
+        accesskey: bWluaW9hZG1pbg==
+        secretkey: bWluaW9hZG1pbg==
+    insecure: true
+    endpoint: minio.kratix-platform-system.svc.cluster.local
+    bucket: kratix
 
+# [DEPRECATED] Use additionalResources instead
 destinations: []
-# Example
-# - name: worker-1
-#   labels:
-#     env: dev
-#   path: ""
-#   filepath:
-#      mode: none | nestedByMetadata
-#   stateStoreRef:
-#     name: default
-#     kind: GitStateStore
-#   strictMatchLabels: false
 
-# -- Array extra K8s resources to deploy
-additionalResources: []
-# Example
+# Addition kratix resources to be created, such as GitStateStores, BucketStateStores and Destinations
+additionalResources:
+#- kind: GitStateStore
+#  apiVersion: platform.kratix.io/v1alpha1
+#  metadata:
+#    name: default
+#  spec:
+#    secretRef:
+#      name: git-credentials
+#      namespace: default
+#    url: https://172.18.0.2:31333/gitea_admin/kratix
+#    branch: main
+#- apiVersion: platform.kratix.io/v1alpha1
+#  kind: Destination
+#  metadata:
+#    name: worker-1
+#    labels:
+#      environment: dev
+#  spec:
+#    stateStoreRef:
+#      name: default
+#      kind: GitStateStore
 # - apiVersion: v1
 #   kind: Secret
 #   metadata:
-#     name: minio-credentials
+#     name: git-credentials
 #     namespace: default
 #   type: Opaque
 #   data:
-#     accesskey: Zm9vCg==
-#     secretkey: Zm9vCg==
+#     username: Zm9vCg==
+#     password: Zm9vCg==

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -77,15 +77,28 @@ skeDeployment:
     # webhookTLSKey:
     # webhookTLSCert:
   additionalResources: []
-  # Example
-  # - kind: Destination
-  #   apiVersion: platform.kratix.io/v1alpha1
-  #   name: worker-1
-  #   labels:
-  #     env: dev
-  #   stateStoreRef:
-  #     name: default
-  #     kind: GitStateStore
-  #   strictMatchLabels: false
+#   Example
+#  - apiVersion: platform.kratix.io/v1alpha1
+#    kind: Destination
+#    metadata:
+#      name: worker-1
+#      labels:
+#        environment: dev
+#    spec:
+#      stateStoreRef:
+#        name: default
+#        kind: BucketStateStore
+#  - kind: BucketStateStore
+#    apiVersion: platform.kratix.io/v1alpha1
+#    metadata:
+#      name: default
+#    spec:
+#      endpoint: minio.kratix-platform-system.svc.cluster.local
+#      insecure: true
+#      bucketName: kratix
+#      authMethod: accessKey
+#      secretRef:
+#        name: minio-credentials
+#        namespace: default
 additionalResources: []
 # Any additional k8s resources, such as Secrets, Configmaps


### PR DESCRIPTION
# Context

This is a follow up from #16
Relates to issue: https://github.com/syntasso/enterprise-kratix/issues/144

Mark statestore and destination has deprecated in example values file and template files.

We have added value `additionalResources` in ske-operator and decided to follow the same pattern for kratix. `statestore` and `destination` values still work, but are marked as deprecated and will be removed in the next release. 