### PR TITLE
fix: run post-install job on the kratix ns

### DIFF
--- a/ske-operator/templates/post-install-job.yaml
+++ b/ske-operator/templates/post-install-job.yaml
@@ -5,6 +5,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: create-additional-resources
+  namespace: kratix-platform-system
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-delete-policy": hook-succeeded


### PR DESCRIPTION
- we execute this job with the ske-operator-controller-manager service
  account
- this service account only exists in the kratix-platform-system
  namespace
- this commit ensures that, even when you install the helm release in a
  different namespace, the job is still scheduled to the kratix ns
