### PR TITLE
fix: support ske upgrade in helm upgrade

### DIFF
--- a/ske-operator/templates/ske-deployment.yaml
+++ b/ske-operator/templates/ske-deployment.yaml
@@ -5,7 +5,7 @@ kind: Kratix
 metadata:
   name: kratix
   annotations:
-    helm.sh/hook: post-install
+    helm.sh/hook: "post-install,post-upgrade"
     "helm.sh/hook-weight": "1"
 spec:
   version: {{ .version | default "latest" }}


### PR DESCRIPTION
## Context

closes #31 
`post-install` hooks are not executed during an upgrade. Adding `post-upgrade` to kratix manifest so that kratix can be updated at `helm upgrade`.