### PR TITLE
chore: add ske-operator upgrade e2e test

### DIFF
--- a/tests/assets/values-with-upgrade.yaml
+++ b/tests/assets/values-with-upgrade.yaml
@@ -7,7 +7,7 @@ global:
 skeLicense: "set via cli arg"
 skeDeployment:
   enabled: true
-  version: "v0.16.0" # older version so we can test upgrade
+  version: "v0.17.0"
   tlsConfig:
     certManager:
       disabled: false


### PR DESCRIPTION
## Context

closes #33 

Add ske-operator upgrade coverage. Assert SKE version change and creationTimeStamp does not match.