### PR TITLE
feat: post hooks deletion policy to before-hook-creation

### DIFF
--- a/ske-operator/templates/post-install-ske-additional-resources.yaml
+++ b/ske-operator/templates/post-install-ske-additional-resources.yaml
@@ -8,7 +8,6 @@ metadata:
   namespace: kratix-platform-system
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
     "helm.sh/hook-weight": "4"
 spec:
   template:

--- a/ske-operator/templates/post-install-ske-deployment.yaml
+++ b/ske-operator/templates/post-install-ske-deployment.yaml
@@ -7,7 +7,6 @@ metadata:
   namespace: kratix-platform-system
   annotations:
     "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": hook-succeeded
     "helm.sh/hook-weight": "3"
 spec:
   template:


### PR DESCRIPTION
## Why

Default hook deletion policy `before-hook-creation` works better for the case of an install or upgrade retry after failure. With delete policy being at hook succeed, if it fails and left around, your next `helm upgrade` will fail due to the job not being cleaned up. User need to manually delete the failed hook to be able to get a successful helm upgrade.