### PR TITLE
fix: add missing path value to Destination

### DIFF
--- a/kratix/README.md
+++ b/kratix/README.md
@@ -48,6 +48,7 @@ additionalResources:
     stateStoreRef:
       name: default
       kind: BucketStateStore
+    path: path/in/statestore
 - apiVersion: v1
   kind: Secret
   metadata:

--- a/kratix/values.yaml
+++ b/kratix/values.yaml
@@ -42,6 +42,7 @@ additionalResources:
 #    stateStoreRef:
 #      name: default
 #      kind: GitStateStore
+#    path: path/in/statestore
 # - apiVersion: v1
 #   kind: Secret
 #   metadata:

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -100,6 +100,7 @@ skeDeployment:
 #      stateStoreRef:
 #        name: default
 #        kind: BucketStateStore
+#      path: path/in/statestore
 #  - kind: BucketStateStore
 #    apiVersion: platform.kratix.io/v1alpha1
 #    metadata:


### PR DESCRIPTION
According to https://docs.kratix.io/main/reference/destinations/intro and my own experiments, the path attribute is required for Destination. So I've added it to the examples. There are also two Destination objects in the tests where I wasn't sure what the correct path would be:
- https://github.com/syntasso/helm-charts/blob/main/tests/assets/values-with-upgrade.yaml#L26
- https://github.com/syntasso/helm-charts/blob/main/tests/assets/values-with-certmanager.yaml#L26