### PR TITLE
feat: add support to override controller image

### DIFF
--- a/kratix/templates/deployment.yaml
+++ b/kratix/templates/deployment.yaml
@@ -19,6 +19,9 @@ spec:
 {{- end }}
 
 {{- define "containerPatch" }}
+{{- if .Values.image }}
+image: {{ .Values.image | quote }}
+{{- end }}
 {{- with .Values.resources }}
 resources:
   {{- . | toYaml | nindent 2 }}

--- a/kratix/values.yaml
+++ b/kratix/values.yaml
@@ -2,6 +2,8 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+image: null
+
 resources:
   limits:
     cpu: 100m


### PR DESCRIPTION
This PR allows users to test a custom controller image in their live environment by overriding the `image` value.