### PR TITLE
feat: configure kratix deployment resources in ske operator chart

### DIFF
--- a/ske-operator/templates/ske-deployment-config.yaml
+++ b/ske-operator/templates/ske-deployment-config.yaml
@@ -13,6 +13,11 @@ data:
       name: kratix
     spec:
       version: {{ .version | default "latest" }}
+      {{- with .deploymentConfig.resources }}
+      deploymentConfig:
+        resources:
+{{- toYaml . | nindent 10 }}
+      {{- end }}
       tlsConfig:
         {{- if ( .tlsConfig.certManager.disabled | default false ) }}
         certSecretName: custom-kratix-platform-serving-cert

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -89,6 +89,14 @@ skeDeployment:
   enabled: true
   # The version to deploy
   version: "latest"
+  deploymentConfig:
+    resources:
+      limits:
+        memory: "100Mi"
+        cpu: "100m"
+      requests:
+        memory: "100Mi"
+        cpu: "100m"
   tlsConfig:
     certManager:
       disabled: false


### PR DESCRIPTION
## Summary

closes #51 

- allow ske-operator chart to specify resources for the kratix deployment
- add default resource configuration values

Templating looks right, haven't installed and upgrade a chart with the changes yet:

Given a values file
```
skeDeployment:
  version: latest
  deploymentConfig:
    resources:
      limits:
        memory: "300Mi"
        cpu: "20m"
      requests:
        memory: "200Mi"
        cpu: "60m"
```

Within the generated manifest we can see:
```
---
# Source: ske-operator/templates/ske-deployment-config.yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: ske-deployment-config
  namespace: kratix-platform-system
data:
  ske-deployment: |
    apiVersion: platform.syntasso.io/v1alpha1
    kind: Kratix
    metadata:
      name: kratix
    spec:
      version: latest
      deploymentConfig:
        resources:
          limits:
            cpu: 20m
            memory: 300Mi
          requests:
            cpu: 60m
            memory: 200Mi
      tlsConfig:
        certManager:
          disabled: false
---
```

## Testing
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_687a32ff7034832888a64fb8993360c7