### PR TITLE
feat: allow custom CA cert for release storage

### DIFF
--- a/ske-operator/templates/operator-config.yaml
+++ b/ske-operator/templates/operator-config.yaml
@@ -59,3 +59,14 @@ metadata:
 type: Opaque
 stringData: {{ toYaml .Values.releaseStorage.bucket.secret.values | nindent 2 }}
 {{ end }}
+
+{{ if and (.Values.releaseStorage) (.Values.releaseStorage.caCertSecret) (.Values.releaseStorage.caCertSecret.values) }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.releaseStorage.caCertSecret.name }}
+  namespace: kratix-platform-system
+type: Opaque
+stringData: {{ toYaml .Values.releaseStorage.caCertSecret.values | nindent 2 }}
+{{ end }}

--- a/ske-operator/templates/ske-operator-deployment.yaml
+++ b/ske-operator/templates/ske-operator-deployment.yaml
@@ -31,6 +31,16 @@ resources:
 {{- $container := index $manifest.spec.template.spec.containers 0
                     | merge (include "containerPatch" . | fromYaml) }}
 
+{{- if and (.Values.releaseStorage) (.Values.releaseStorage.caCertSecret) (.Values.releaseStorage.caCertSecret.name) }}
+{{- $caMountPath := "/etc/ssl/certs/release-storage-ca" }}
+{{- $caVolumeMount := dict "name" "release-storage-ca" "mountPath" $caMountPath "readOnly" true }}
+{{- $_ := set $container "volumeMounts" (append ($container.volumeMounts | default (list)) $caVolumeMount) }}
+{{- $caEnv := dict "name" "SSL_CERT_FILE" "value" (printf "%s/ca.crt" $caMountPath) }}
+{{- $_ := set $container "env" (append ($container.env | default (list)) $caEnv) }}
+{{- $caVolume := dict "name" "release-storage-ca" "secret" (dict "secretName" .Values.releaseStorage.caCertSecret.name) }}
+{{- $_ := set $manifest.spec.template.spec "volumes" (append ($manifest.spec.template.spec.volumes | default (list)) $caVolume) }}
+{{- end }}
+
 {{/* Apply image configuration from kustomization.yaml */}}
 {{- $originalImage := "registry.syntasso.io/syntasso/ske-operator" }}
 {{- $newName := printf "%s/%s" .Values.imageRegistry.host .Values.imageRegistry.skeOperatorImage.name }}

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -71,6 +71,16 @@ releaseStorage:
     #   values:
     #     accessKeyID: "my-access"
     #     secretAccessKey: "my-secret"
+
+  # Optionally provide a CA certificate for accessing the release storage
+  # endpoints. The referenced secret must contain a key named `ca.crt`.
+  # caCertSecret:
+  #   name: "my-ca-secret" # Secret in the same namespace as the operator
+  #   values:
+  #     ca.crt: |-
+  #       -----BEGIN CERTIFICATE-----
+  #       ...
+  #       -----END CERTIFICATE-----
 skeOperator:
   # Set if you want to change the resources for the operator container
   resources:


### PR DESCRIPTION
## Summary
- allow providing custom CA certificate secret for release storage
- mount CA certificate into operator pod and set `SSL_CERT_FILE`

## Testing
- `go test ./...` *(fails: pattern ./...: directory prefix . does not contain main module or its selected dependencies)*
- `cd tests && go test ./...` *(fails: `SKE_LICENSE_TOKEN` must be set)*


------
https://chatgpt.com/codex/tasks/task_b_6890bc2b1b3883289d8809465d8ccaca