### PR TITLE
chore: bump kratix deployment memory request&limit

### DIFF
--- a/kratix/values.yaml
+++ b/kratix/values.yaml
@@ -7,10 +7,10 @@ image: null
 resources:
   limits:
     cpu: 100m
-    memory: 100Mi
+    memory: 256Mi
   requests:
     cpu: 100m
-    memory: 100Mi
+    memory: 256Mi
 
 nodeSelector: {}
 

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -106,10 +106,10 @@ skeDeployment:
   deploymentConfig:
     resources:
       limits:
-        memory: "100Mi"
+        memory: "256Mi"
         cpu: "100m"
       requests:
-        memory: "100Mi"
+        memory: "256Mi"
         cpu: "100m"
   tlsConfig:
     certManager:


### PR DESCRIPTION
## Context

Bump kratix operator deployment memory requests and limits in both kratix and ske-operator chart. relates to issue: https://github.com/syntasso/enterprise-kratix/issues/465