### PR TITLE
fix: template imagePullSecrets in post deploy job

### DIFF
--- a/ske-operator/templates/post-install-ske-additional-resources.yaml
+++ b/ske-operator/templates/post-install-ske-additional-resources.yaml
@@ -14,6 +14,8 @@ spec:
     spec:
       serviceAccountName: ske-operator-controller-manager
       restartPolicy: Never
+      imagePullSecrets:
+        - name: '{{ .Values.imageRegistry.imagePullSecret | default "syntasso-registry" }}'
       containers:
         - name: deploy-resources
           image: {{ .Values.imageRegistry.host }}/{{ .Values.imageRegistry.skeOperatorImage.name }}:{{ .Chart.AppVersion }}

--- a/ske-operator/templates/post-install-ske-deployment.yaml
+++ b/ske-operator/templates/post-install-ske-deployment.yaml
@@ -13,6 +13,8 @@ spec:
     spec:
       serviceAccountName: ske-operator-controller-manager
       restartPolicy: Never
+      imagePullSecrets:
+        - name: '{{ .Values.imageRegistry.imagePullSecret | default "syntasso-registry" }}'
       containers:
         - name: deploy-ske
           image: {{ .Values.imageRegistry.host }}/{{ .Values.imageRegistry.skeOperatorImage.name }}:{{ .Chart.AppVersion }}


### PR DESCRIPTION
Previously, the image used was public, so no secret was necessary; it is
now private, so we need to template the secret

closes #75
