### PR TITLE
feat: more control over the image pull secret

### DIFF
--- a/.github/workflows/run-ci.yaml
+++ b/.github/workflows/run-ci.yaml
@@ -132,6 +132,9 @@ jobs:
               - 'ske-gui/**'
               - 'tests/chart-tests.bats'
               - 'scripts/test-charts.sh'
+            ske-operator-chart-tests:
+              - 'ske-operator/**'
+              - 'tests/ske-operator/**'
 
       - name: Install Helm
         uses: azure/setup-helm@v3
@@ -149,6 +152,14 @@ jobs:
           BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
           TERM: xterm
         run: bats tests/chart-tests.bats
+
+      - name: Run ske-operator chart tests
+        if: ${{ steps.chart-test-changes.outputs.ske-operator-chart-tests == 'true' || (github.event_name == 'workflow_dispatch' && inputs.helm_chart_name == 'ske-operator') }}
+        shell: bash
+        env:
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
+          TERM: xterm
+        run: bats tests/ske-operator/
 
   update-and-release:
     if: ${{ !startsWith(github.ref, 'refs/tags/') && (needs.test.result == 'success' || needs.test.result == 'skipped') && (needs.chart-tests.result == 'success' || needs.chart-tests.result == 'skipped') }}

--- a/ske-operator/kustomization.yaml
+++ b/ske-operator/kustomization.yaml
@@ -11,7 +11,7 @@ patches:
       - op: replace
         path: /spec/template/spec/imagePullSecrets
         value:
-          - name: '{{ .Values.imageRegistry.imagePullSecret | default "syntasso-registry" }}'
+          - name: '{{ .Values.imageRegistry.imagePullSecret }}'
 
 # patches:
 #   - target:

--- a/ske-operator/templates/_helpers.tpl
+++ b/ske-operator/templates/_helpers.tpl
@@ -68,6 +68,19 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Returns "true" if the chart should create the registry pull secret, "false" otherwise.
+When imageRegistry.createRegistrySecret is explicitly set, that value is used.
+When not set, defaults to true if skeLicense is provided, false otherwise.
+*/}}
+{{- define "ske-operator.createRegistrySecret" -}}
+{{- if hasKey .Values.imageRegistry "createRegistrySecret" -}}
+{{- .Values.imageRegistry.createRegistrySecret -}}
+{{- else -}}
+{{- ne "" (default "" .Values.skeLicense) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Render the release storage location while keeping backward compatibility with
 releaseStorage.path during the deprecation window.
 */}}

--- a/ske-operator/templates/_helpers.tpl
+++ b/ske-operator/templates/_helpers.tpl
@@ -68,15 +68,31 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
-Returns "true" if the chart should create the registry pull secret, "false" otherwise.
-When imageRegistry.createRegistrySecret is explicitly set, that value is used.
-When not set, defaults to true if skeLicense is provided, false otherwise.
+Returns "true" if the chart should create and manage the pull secret from
+skeLicense, "false" otherwise.
+When imageRegistry.managePullSecret is explicitly set, that value is honoured.
+When absent, defaults to true if skeLicense is provided, false otherwise —
+preserving backwards compatibility for existing installations.
 */}}
-{{- define "ske-operator.createRegistrySecret" -}}
-{{- if hasKey .Values.imageRegistry "createRegistrySecret" -}}
-{{- .Values.imageRegistry.createRegistrySecret -}}
+{{- define "ske-operator.managePullSecret" -}}
+{{- if hasKey .Values.imageRegistry "managePullSecret" -}}
+{{- .Values.imageRegistry.managePullSecret -}}
 {{- else -}}
 {{- ne "" (default "" .Values.skeLicense) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns the effective image pull secret name injected into all workloads.
+When the chart manages the secret (managePullSecret=true) the name is always
+"syntasso-registry". Otherwise falls back to imageRegistry.imagePullSecret,
+which may be empty (no imagePullSecrets injected).
+*/}}
+{{- define "ske-operator.effectivePullSecretName" -}}
+{{- if eq (include "ske-operator.managePullSecret" . | trim) "true" -}}
+syntasso-registry
+{{- else -}}
+{{- default "" .Values.imageRegistry.imagePullSecret -}}
 {{- end -}}
 {{- end -}}
 

--- a/ske-operator/templates/operator-config.yaml
+++ b/ske-operator/templates/operator-config.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  creationTimestamp: null
   name: ske-operator
   namespace: kratix-platform-system
 data:
@@ -33,7 +32,7 @@ data:
     imageRegistry:
     {{- with .Values.imageRegistry }}
       host: {{ .host }}
-      pullSecret: {{ .imagePullSecret | default "syntasso-registry" }}
+      pullSecret: {{ .imagePullSecret }}
       platformImage: {{ .skePlatformImage.name }}
       pipelineImage: {{ .skePlatformPipelineAdapterImage.name }}
       backstageControllerImage: {{ .backstageControllerImage.name }}

--- a/ske-operator/templates/operator-config.yaml
+++ b/ske-operator/templates/operator-config.yaml
@@ -32,7 +32,7 @@ data:
     imageRegistry:
     {{- with .Values.imageRegistry }}
       host: {{ .host }}
-      pullSecret: {{ .imagePullSecret }}
+      pullSecret: {{ include "ske-operator.effectivePullSecretName" $ | trim }}
       platformImage: {{ .skePlatformImage.name }}
       pipelineImage: {{ .skePlatformPipelineAdapterImage.name }}
       backstageControllerImage: {{ .backstageControllerImage.name }}

--- a/ske-operator/templates/post-install-backstage-integration.yaml
+++ b/ske-operator/templates/post-install-backstage-integration.yaml
@@ -18,8 +18,10 @@ spec:
     spec:
       serviceAccountName: ske-operator-controller-manager
       restartPolicy: Never
+      {{- if $root.Values.imageRegistry.imagePullSecret }}
       imagePullSecrets:
-        - name: '{{ $root.Values.imageRegistry.imagePullSecret | default "syntasso-registry" }}'
+        - name: {{ $root.Values.imageRegistry.imagePullSecret | quote }}
+      {{- end }}
       containers:
         - name: deploy-ske
           image: {{ $root.Values.imageRegistry.host }}/{{ $root.Values.imageRegistry.skeOperatorImage.name }}:{{ $root.Chart.AppVersion }}

--- a/ske-operator/templates/post-install-backstage-integration.yaml
+++ b/ske-operator/templates/post-install-backstage-integration.yaml
@@ -18,9 +18,10 @@ spec:
     spec:
       serviceAccountName: ske-operator-controller-manager
       restartPolicy: Never
-      {{- if $root.Values.imageRegistry.imagePullSecret }}
+      {{- $pullSecret := (include "ske-operator.effectivePullSecretName" $root | trim) -}}
+      {{- if $pullSecret }}
       imagePullSecrets:
-        - name: {{ $root.Values.imageRegistry.imagePullSecret | quote }}
+        - name: {{ $pullSecret | quote }}
       {{- end }}
       containers:
         - name: deploy-ske

--- a/ske-operator/templates/post-install-cortex-integration.yaml
+++ b/ske-operator/templates/post-install-cortex-integration.yaml
@@ -18,8 +18,10 @@ spec:
     spec:
       serviceAccountName: ske-operator-controller-manager
       restartPolicy: Never
+      {{- if $root.Values.imageRegistry.imagePullSecret }}
       imagePullSecrets:
-        - name: '{{ $root.Values.imageRegistry.imagePullSecret | default "syntasso-registry" }}'
+        - name: {{ $root.Values.imageRegistry.imagePullSecret | quote }}
+      {{- end }}
       containers:
         - name: deploy-ske
           image: {{ $root.Values.imageRegistry.host }}/{{ $root.Values.imageRegistry.skeOperatorImage.name }}:{{ $root.Chart.AppVersion }}

--- a/ske-operator/templates/post-install-cortex-integration.yaml
+++ b/ske-operator/templates/post-install-cortex-integration.yaml
@@ -18,9 +18,10 @@ spec:
     spec:
       serviceAccountName: ske-operator-controller-manager
       restartPolicy: Never
-      {{- if $root.Values.imageRegistry.imagePullSecret }}
+      {{- $pullSecret := (include "ske-operator.effectivePullSecretName" $root | trim) -}}
+      {{- if $pullSecret }}
       imagePullSecrets:
-        - name: {{ $root.Values.imageRegistry.imagePullSecret | quote }}
+        - name: {{ $pullSecret | quote }}
       {{- end }}
       containers:
         - name: deploy-ske

--- a/ske-operator/templates/post-install-ske-additional-resources.yaml
+++ b/ske-operator/templates/post-install-ske-additional-resources.yaml
@@ -14,9 +14,10 @@ spec:
     spec:
       serviceAccountName: ske-operator-controller-manager
       restartPolicy: Never
-      {{- if .Values.imageRegistry.imagePullSecret }}
+      {{- $pullSecret := (include "ske-operator.effectivePullSecretName" . | trim) -}}
+      {{- if $pullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.imageRegistry.imagePullSecret | quote }}
+        - name: {{ $pullSecret | quote }}
       {{- end }}
       containers:
         - name: deploy-resources

--- a/ske-operator/templates/post-install-ske-additional-resources.yaml
+++ b/ske-operator/templates/post-install-ske-additional-resources.yaml
@@ -14,8 +14,10 @@ spec:
     spec:
       serviceAccountName: ske-operator-controller-manager
       restartPolicy: Never
+      {{- if .Values.imageRegistry.imagePullSecret }}
       imagePullSecrets:
-        - name: '{{ .Values.imageRegistry.imagePullSecret | default "syntasso-registry" }}'
+        - name: {{ .Values.imageRegistry.imagePullSecret | quote }}
+      {{- end }}
       containers:
         - name: deploy-resources
           image: {{ .Values.imageRegistry.host }}/{{ .Values.imageRegistry.skeOperatorImage.name }}:{{ .Chart.AppVersion }}

--- a/ske-operator/templates/post-install-ske-deployment.yaml
+++ b/ske-operator/templates/post-install-ske-deployment.yaml
@@ -13,8 +13,10 @@ spec:
     spec:
       serviceAccountName: ske-operator-controller-manager
       restartPolicy: Never
+      {{- if .Values.imageRegistry.imagePullSecret }}
       imagePullSecrets:
-        - name: '{{ .Values.imageRegistry.imagePullSecret | default "syntasso-registry" }}'
+        - name: {{ .Values.imageRegistry.imagePullSecret | quote }}
+      {{- end }}
       containers:
         - name: deploy-ske
           image: {{ .Values.imageRegistry.host }}/{{ .Values.imageRegistry.skeOperatorImage.name }}:{{ .Chart.AppVersion }}

--- a/ske-operator/templates/post-install-ske-deployment.yaml
+++ b/ske-operator/templates/post-install-ske-deployment.yaml
@@ -13,9 +13,10 @@ spec:
     spec:
       serviceAccountName: ske-operator-controller-manager
       restartPolicy: Never
-      {{- if .Values.imageRegistry.imagePullSecret }}
+      {{- $pullSecret := (include "ske-operator.effectivePullSecretName" . | trim) -}}
+      {{- if $pullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.imageRegistry.imagePullSecret | quote }}
+        - name: {{ $pullSecret | quote }}
       {{- end }}
       containers:
         - name: deploy-ske

--- a/ske-operator/templates/registry-secret.yaml
+++ b/ske-operator/templates/registry-secret.yaml
@@ -1,8 +1,9 @@
-{{- if not .Values.imageRegistry.imagePullSecret }}
+{{- $createSecret := (include "ske-operator.createRegistrySecret" .) | trim -}}
+{{- if and (eq $createSecret "true") .Values.imageRegistry.imagePullSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: syntasso-registry
+  name: {{ .Values.imageRegistry.imagePullSecret }}
   namespace: kratix-platform-system
 {{- if or (not .Values.global.skeDeployment) (eq (default false .Values.global.skeDeployment.deleteOnUninstall) false) }}
   annotations:

--- a/ske-operator/templates/registry-secret.yaml
+++ b/ske-operator/templates/registry-secret.yaml
@@ -1,9 +1,11 @@
-{{- $createSecret := (include "ske-operator.createRegistrySecret" .) | trim -}}
-{{- if and (eq $createSecret "true") .Values.imageRegistry.imagePullSecret }}
+{{- if eq (include "ske-operator.managePullSecret" . | trim) "true" -}}
+{{- if not .Values.skeLicense -}}
+{{- fail "imageRegistry.managePullSecret is true but skeLicense is not set. Provide skeLicense so the chart can create the registry pull secret, or set imageRegistry.managePullSecret: false to manage it yourself." -}}
+{{- end -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Values.imageRegistry.imagePullSecret }}
+  name: syntasso-registry
   namespace: kratix-platform-system
 {{- if or (not .Values.global.skeDeployment) (eq (default false .Values.global.skeDeployment.deleteOnUninstall) false) }}
   annotations:

--- a/ske-operator/templates/ske-operator-deployment.yaml
+++ b/ske-operator/templates/ske-operator-deployment.yaml
@@ -16,8 +16,10 @@ spec:
       affinity:
         {{- . | toYaml | nindent 8 }}
       {{- end }}
+      {{- if .Values.imageRegistry.imagePullSecret }}
       imagePullSecrets:
-        - name: '{{ .Values.imageRegistry.imagePullSecret | default "syntasso-registry" }}'
+        - name: {{ .Values.imageRegistry.imagePullSecret | quote }}
+      {{- end }}
 {{- end }}
 
 {{- define "containerPatch" }}

--- a/ske-operator/templates/ske-operator-deployment.yaml
+++ b/ske-operator/templates/ske-operator-deployment.yaml
@@ -16,9 +16,10 @@ spec:
       affinity:
         {{- . | toYaml | nindent 8 }}
       {{- end }}
-      {{- if .Values.imageRegistry.imagePullSecret }}
+      {{- $pullSecret := (include "ske-operator.effectivePullSecretName" . | trim) -}}
+      {{- if $pullSecret }}
       imagePullSecrets:
-        - name: {{ .Values.imageRegistry.imagePullSecret | quote }}
+        - name: {{ $pullSecret | quote }}
       {{- end }}
 {{- end }}
 

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -29,7 +29,7 @@ global:
 # Used wherever the license is required (e.g. pull secret creation). Setting
 # this field alone is sufficient for the most common installation. See
 # imageRegistry.managePullSecret below.
-skeLicense: "my-ske-license"
+skeLicense: ""
 
 # Configuration for the Registry and Manifests
 # Update these values if you are using a custom registry or bucket

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -23,12 +23,14 @@ global:
   # skeDeployment:
   # WARNING: when skeDeployment.deleteOnUninstall is true, uninstalling this helm chart will delete your SKE platform
   # only set to true for dev or testing environments
-  # deleteOnUninstall: false
+  #   deleteOnUninstall: false
+
 # Your SKE License Key.
 # To avoid storing the license in plain text (e.g. for GitOps workflows), omit this field and
 # instead pre-create a kubernetes.io/dockerconfigjson Secret manually, then set
 # imageRegistry.imagePullSecret to its name. The chart will skip creating the pull secret.
 skeLicense: "my-ske-license"
+
 # Configuration for the Registry and Manifests
 # Update these values if you are using a custom registry or bucket
 # If using Syntasso Enterprise defaults, no changes are required
@@ -40,7 +42,18 @@ imageRegistry:
   # The name of an existing image pull secret to use instead of creating one from skeLicense above.
   # Use this for GitOps workflows to avoid storing the license in Helm values:
   # pre-create a kubernetes.io/dockerconfigjson Secret and set its name here.
-  # imagePullSecret: "my-secret"
+
+  # The name of the pull secret used by all workloads to pull images.
+  # If empty or not set, no imagePullSecrets are injected and the cluster must
+  # be able to pull images without a secret.
+  imagePullSecret: "syntasso-registry"
+
+  # Controls whether the chart creates the registry pull secret from skeLicense.
+  # When not set, defaults to true if skeLicense is provided, false otherwise.
+  # Set to false explicitly if you have pre-created the secret yourself and do
+  # not want the chart to manage it, even when skeLicense is also set.
+  # createRegistrySecret: false
+
   skeOperatorImage:
     # The name of the SKE operator use. Update this if you are using a custom image name for the operator
     name: "syntasso/ske-operator"

--- a/tests/chart-tests.bats
+++ b/tests/chart-tests.bats
@@ -1,8 +1,7 @@
 #!/usr/bin/env bats
 
 # Chart tests: helm template + assertions. Run from repo root: bats tests/chart-tests.bats
-# Requires: helm, bats (bats-core)
-
+# Requires: helm, bats (bats-core), yq
 
 setup_file() {
   export REPO_ROOT
@@ -11,9 +10,7 @@ setup_file() {
   command -v yq >/dev/null || { echo "yq not found"; exit 1; }
 }
 
-ske_operator_config() {
-  printf '%s\n' "$1" | yq 'select(.kind == "ConfigMap" and .metadata.name == "ske-operator").data.config'
-}
+# --- ske-gui ---
 
 @test "ske-gui OIDC with secretRef: does not create a secret" {
   run helm template test "$REPO_ROOT/ske-gui" \
@@ -31,7 +28,6 @@ ske_operator_config() {
     --set oidc.secretRef.key=custom-secret-key
   local deployment=$(echo "$output" | yq '.spec.template.spec.containers[0].env[] | select(.name == "OIDC_CLIENT_SECRET")')
 
-  # assert with yq
   [[ $(echo "$deployment" | yq '.valueFrom.secretKeyRef.name') == "custom-secret-name" ]]
   [[ $(echo "$deployment" | yq '.valueFrom.secretKeyRef.key') == "custom-secret-key" ]]
 }
@@ -49,53 +45,7 @@ ske_operator_config() {
   [[ $(echo "$deployment" | yq '.valueFrom.secretKeyRef.key') == "clientSecret" ]]
 }
 
-@test "ske-operator releaseStorage.releasesPath: renders releasesPath in config" {
-  run helm template test "$REPO_ROOT/ske-operator" \
-    --set-string releaseStorage.releasesPath=platform-releases
-  [ "$status" -eq 0 ]
-
-  local config
-  config="$(ske_operator_config "$output")"
-
-  [[ $(printf '%s\n' "$config" | yq '.releaseStorage.releasesPath') == "platform-releases" ]]
-  [[ $(printf '%s\n' "$config" | yq '.releaseStorage.path') == "null" ]]
-}
-
-@test "ske-operator releaseStorage.path: legacy key still renders releasesPath" {
-  run helm template test "$REPO_ROOT/ske-operator" \
-    --set-string releaseStorage.releasesPath= \
-    --set-string releaseStorage.path=legacy-path
-  [ "$status" -eq 0 ]
-
-  local config
-  config="$(ske_operator_config "$output")"
-
-  [[ $(printf '%s\n' "$config" | yq '.releaseStorage.path') == "legacy-path" ]]
-  [[ $(printf '%s\n' "$config" | yq '.releaseStorage.releasesPath') == "null" ]]
-}
-
-@test "ske-operator releaseStorage.path and releaseStorage.releasesPath: helm template fails" {
-  run helm template test "$REPO_ROOT/ske-operator" \
-    --set-string releaseStorage.path=legacy-path \
-    --set-string releaseStorage.releasesPath=new-path
-
-  [ "$status" -ne 0 ]
-  [[ "$output" == *"releaseStorage.path and releaseStorage.releasesPath are mutually exclusive"* ]]
-}
-
-@test "ske-operator imagePullSecret set: registry-secret is not rendered and deployments reference the given secret" {
-  run helm template test "$REPO_ROOT/ske-operator" \
-    --set imageRegistry.imagePullSecret=my-existing-pull-secret \
-    --set skeLicense=""
-  [ "$status" -eq 0 ]
-  local secrets
-  secrets=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret") | .metadata.name')
-  [[ "$secrets" != *"syntasso-registry"* ]]
-  local pull_secrets
-  pull_secrets=$(printf '%s\n' "$output" | yq 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets[].name')
-  [[ "$pull_secrets" == *"my-existing-pull-secret"* ]]
-  [[ "$pull_secrets" != *"syntasso-registry"* ]]
-}
+# --- k8s-health-agent ---
 
 @test "k8s-health-agent imagePullSecret set: registry-secret is not rendered and deployment references the given secret" {
   run helm template test "$REPO_ROOT/k8s-health-agent" \
@@ -109,76 +59,4 @@ ske_operator_config() {
   pull_secrets=$(printf '%s\n' "$output" | yq 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets[].name')
   [[ "$pull_secrets" == *"my-existing-pull-secret"* ]]
   [[ "$pull_secrets" != *"syntasso-registry"* ]]
-}
-
-@test "ske-operator TLS certManager 'disabled=true': both secrets rendered when no secretRefs set" {
-  run helm template test "$REPO_ROOT/ske-operator" \
-    --set skeDeployment.tlsConfig.certManager.disabled=true \
-    --set-string skeDeployment.tlsConfig.webhookCACert=ca \
-    --set-string skeDeployment.tlsConfig.webhookTLSCert=cert \
-    --set-string skeDeployment.tlsConfig.webhookTLSKey=key \
-    --set-string skeDeployment.tlsConfig.metricsServerCACert=ca \
-    --set-string skeDeployment.tlsConfig.metricsServerTLSCert=cert \
-    --set-string skeDeployment.tlsConfig.metricsServerTLSKey=key
-  [ "$status" -eq 0 ]
-  local tls_secrets
-  tls_secrets=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret") | .metadata.name')
-  [[ "$tls_secrets" == *"custom-kratix-platform-serving-cert"* ]]
-  [[ "$tls_secrets" == *"custom-kratix-platform-metrics-server-cert"* ]]
-}
-
-@test "ske-operator TLS certManager 'disabled=true' and webhookTLSSecretRef is provided: webhook secret not created, configmap uses given name" {
-  run helm template test "$REPO_ROOT/ske-operator" \
-    --set skeDeployment.tlsConfig.certManager.disabled=true \
-    --set skeDeployment.tlsConfig.webhookTLSSecretRef.name=my-webhook-tls-secret \
-    --set-string skeDeployment.tlsConfig.metricsServerCACert=ca \
-    --set-string skeDeployment.tlsConfig.metricsServerTLSCert=cert \
-    --set-string skeDeployment.tlsConfig.metricsServerTLSKey=key
-  [ "$status" -eq 0 ]
-  local tls_secrets
-  tls_secrets=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret") | .metadata.name')
-  [[ "$tls_secrets" != *"my-webhook-tls-secret"* ]]
-  [[ "$tls_secrets" == *"custom-kratix-platform-metrics-server-cert"* ]]
-
-  local cert_secret_name
-  cert_secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "ConfigMap" and .metadata.name == "ske-deployment-config") | .data["ske-deployment"]' | yq '.spec.tlsConfig.certSecretName')
-  [[ "$cert_secret_name" == "my-webhook-tls-secret" ]]
-}
-
-@test "ske-operator TLS certManager 'disabled=true' and metricsServerTLSSecretRef: metrics secret not created, configmap uses given name" {
-  run helm template test "$REPO_ROOT/ske-operator" \
-    --set skeDeployment.tlsConfig.certManager.disabled=true \
-    --set-string skeDeployment.tlsConfig.webhookCACert=ca \
-    --set-string skeDeployment.tlsConfig.webhookTLSCert=cert \
-    --set-string skeDeployment.tlsConfig.webhookTLSKey=key \
-    --set skeDeployment.tlsConfig.metricsServerTLSSecretRef.name=my-metrics-tls-secret
-  [ "$status" -eq 0 ]
-  local tls_secrets
-  tls_secrets=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret") | .metadata.name')
-  [[ "$tls_secrets" == *"custom-kratix-platform-serving-cert"* ]]
-  [[ "$tls_secrets" != *"my-metrics-tls-secret"* ]]
-
-  local metrics_cert_secret_name
-  metrics_cert_secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "ConfigMap" and .metadata.name == "ske-deployment-config") | .data["ske-deployment"]' | yq '.spec.tlsConfig.metricsServerCertSecretName')
-  [[ "$metrics_cert_secret_name" == "my-metrics-tls-secret" ]]
-}
-
-@test "ske-operator TLS both secretRefs set: neither TLS secret created" {
-  run helm template test "$REPO_ROOT/ske-operator" \
-    --set skeDeployment.tlsConfig.certManager.disabled=true \
-    --set skeDeployment.tlsConfig.webhookTLSSecretRef.name=my-webhook-tls-secret \
-    --set skeDeployment.tlsConfig.metricsServerTLSSecretRef.name=my-metrics-tls-secret
-  [ "$status" -eq 0 ]
-  local tls_secrets
-  tls_secrets=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret") | .metadata.name')
-  [[ "$tls_secrets" != *"my-webhook-tls-secret"* ]]
-  [[ "$tls_secrets" != *"my-metrics-tls-secret"* ]]
-
-  local metrics_cert_secret_name
-  metrics_cert_secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "ConfigMap" and .metadata.name == "ske-deployment-config") | .data["ske-deployment"]' | yq '.spec.tlsConfig.metricsServerCertSecretName')
-  [[ "$metrics_cert_secret_name" == "my-metrics-tls-secret" ]]
-
-  local cert_secret_name
-  cert_secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "ConfigMap" and .metadata.name == "ske-deployment-config") | .data["ske-deployment"]' | yq '.spec.tlsConfig.certSecretName')
-  [[ "$cert_secret_name" == "my-webhook-tls-secret" ]]
 }

--- a/tests/ske-operator/helpers.bash
+++ b/tests/ske-operator/helpers.bash
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Shared helpers for ske-operator bats tests.
+# Load in each test file with: load helpers
+
+setup_file() {
+  export REPO_ROOT
+  REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+  command -v helm >/dev/null || { echo "helm not found"; exit 1; }
+  command -v yq >/dev/null || { echo "yq not found"; exit 1; }
+}
+
+# Runs helm template for the ske-operator chart.
+# Usage: run helm_ske_operator [--set key=value ...]
+helm_ske_operator() {
+  helm template test "$REPO_ROOT/ske-operator" "$@"
+}
+
+# Extracts the ske-operator ConfigMap config as YAML from helm output.
+# Usage: config="$(ske_operator_config "$output")"
+ske_operator_config() {
+  printf '%s\n' "$1" | yq 'select(.kind == "ConfigMap" and .metadata.name == "ske-operator").data.config'
+}
+
+# Extracts the ske-deployment ConfigMap config as YAML from helm output.
+# Usage: config="$(ske_deployment_config "$output")"
+ske_deployment_config() {
+  printf '%s\n' "$1" | yq 'select(.kind == "ConfigMap" and .metadata.name == "ske-deployment-config") | .data["ske-deployment"]'
+}

--- a/tests/ske-operator/image-pull-secret-tests.bats
+++ b/tests/ske-operator/image-pull-secret-tests.bats
@@ -1,0 +1,200 @@
+#!/usr/bin/env bats
+
+load helpers
+
+# --- secret creation ---
+
+@test "skeLicense set: registry secret is created with default imagePullSecret name" {
+  run helm_ske_operator \
+    --set skeLicense="abc123"
+  [ "$status" -eq 0 ]
+
+  local secret_name
+  secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .type == "kubernetes.io/dockerconfigjson") | .metadata.name')
+  [[ "$secret_name" == "syntasso-registry" ]]
+}
+
+@test "skeLicense set: registry secret uses custom imagePullSecret name" {
+  run helm_ske_operator \
+    --set skeLicense="abc123" \
+    --set imageRegistry.imagePullSecret=myorg-secret
+  [ "$status" -eq 0 ]
+
+  local secret_name
+  secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .type == "kubernetes.io/dockerconfigjson") | .metadata.name')
+  [[ "$secret_name" == "myorg-secret" ]]
+}
+
+@test "skeLicense empty: registry secret is not created" {
+  run helm_ske_operator \
+    --set skeLicense=""
+  [ "$status" -eq 0 ]
+
+  local secret_name
+  secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .type == "kubernetes.io/dockerconfigjson") | .metadata.name')
+  [[ -z "$secret_name" ]]
+}
+
+@test "createRegistrySecret: false: registry secret is not created even when skeLicense is set" {
+  run helm_ske_operator \
+    --set skeLicense="abc123" \
+    --set imageRegistry.createRegistrySecret=false
+  [ "$status" -eq 0 ]
+
+  local secret_name
+  secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .type == "kubernetes.io/dockerconfigjson") | .metadata.name')
+  [[ -z "$secret_name" ]]
+}
+
+@test "createRegistrySecret: false: registry secret is not created when imagePullSecret is also custom" {
+  run helm_ske_operator \
+    --set skeLicense="abc123" \
+    --set imageRegistry.imagePullSecret=my-preexisting-secret \
+    --set imageRegistry.createRegistrySecret=false
+  [ "$status" -eq 0 ]
+
+  local secret_name
+  secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .type == "kubernetes.io/dockerconfigjson") | .metadata.name')
+  [[ -z "$secret_name" ]]
+}
+
+@test "imagePullSecret empty: registry secret is not created even when skeLicense is set" {
+  run helm_ske_operator \
+    --set skeLicense="abc123" \
+    --set imageRegistry.imagePullSecret=""
+  [ "$status" -eq 0 ]
+
+  local secret_name
+  secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .type == "kubernetes.io/dockerconfigjson") | .metadata.name')
+  [[ -z "$secret_name" ]]
+}
+
+# --- imagePullSecrets on workloads ---
+
+@test "imagePullSecret set: operator deployment references it" {
+  run helm_ske_operator \
+    --set imageRegistry.imagePullSecret=syntasso-registry \
+    --set skeLicense="abc123"
+  [ "$status" -eq 0 ]
+
+  local pull_secret
+  pull_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets[].name')
+  [[ "$pull_secret" == *"syntasso-registry"* ]]
+}
+
+@test "imagePullSecret set: deploy-ske-deployment job references it" {
+  run helm_ske_operator \
+    --set imageRegistry.imagePullSecret=syntasso-registry \
+    --set skeLicense="abc123"
+  [ "$status" -eq 0 ]
+
+  local pull_secret
+  pull_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Job" and .metadata.name == "deploy-ske-deployment") | .spec.template.spec.imagePullSecrets[].name')
+  [[ "$pull_secret" == "syntasso-registry" ]]
+}
+
+@test "imagePullSecret set: backstage job references it" {
+  run helm_ske_operator \
+    --set imageRegistry.imagePullSecret=syntasso-registry \
+    --set skeLicense="abc123" \
+    --set backstageIntegration.enabled=true \
+    --set backstageIntegration.version=v0.6.0
+  [ "$status" -eq 0 ]
+
+  local pull_secret
+  pull_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Job" and .metadata.name == "deploy-backstage-integration") | .spec.template.spec.imagePullSecrets[].name')
+  [[ "$pull_secret" == "syntasso-registry" ]]
+}
+
+@test "imagePullSecret set: cortex job references it" {
+  run helm_ske_operator \
+    --set imageRegistry.imagePullSecret=syntasso-registry \
+    --set skeLicense="abc123" \
+    --set cortexIntegration.enabled=true \
+    --set cortexIntegration.config.integrationAlias=test \
+    --set cortexIntegration.config.provider=github \
+    --set cortexIntegration.config.repositoryName=test/repo \
+    --set cortexIntegration.config.token=mytoken \
+    --set cortexIntegration.config.url=https://cortex.example.com
+  [ "$status" -eq 0 ]
+
+  local pull_secret
+  pull_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Job" and .metadata.name == "deploy-cortex-integration") | .spec.template.spec.imagePullSecrets[].name')
+  [[ "$pull_secret" == "syntasso-registry" ]]
+}
+
+@test "imagePullSecret empty: no imagePullSecrets on operator deployment" {
+  run helm_ske_operator \
+    --set imageRegistry.imagePullSecret="" \
+    --set skeLicense="abc123"
+  [ "$status" -eq 0 ]
+
+  local pull_secrets
+  pull_secrets=$(printf '%s\n' "$output" | yq 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets[].name')
+  [[ -z "$pull_secrets" ]]
+}
+
+@test "imagePullSecret empty: no imagePullSecrets on any job" {
+  run helm_ske_operator \
+    --set imageRegistry.imagePullSecret="" \
+    --set skeLicense="abc123" \
+    --set backstageIntegration.enabled=true \
+    --set backstageIntegration.version=v0.6.0 \
+    --set cortexIntegration.enabled=true \
+    --set cortexIntegration.config.integrationAlias=test \
+    --set cortexIntegration.config.provider=github \
+    --set cortexIntegration.config.repositoryName=test/repo \
+    --set cortexIntegration.config.token=mytoken \
+    --set cortexIntegration.config.url=https://cortex.example.com
+  [ "$status" -eq 0 ]
+
+  local pull_secrets
+  pull_secrets=$(printf '%s\n' "$output" | yq 'select(.kind == "Job") | .spec.template.spec.imagePullSecrets[].name')
+  [[ -z "$pull_secrets" ]]
+}
+
+# --- createRegistrySecret: false still injects the secret name into workloads ---
+
+@test "createRegistrySecret: false: workloads still reference the imagePullSecret name" {
+  run helm_ske_operator \
+    --set skeLicense="abc123" \
+    --set imageRegistry.imagePullSecret=my-preexisting-secret \
+    --set imageRegistry.createRegistrySecret=false
+  [ "$status" -eq 0 ]
+
+  local deployment_secret
+  deployment_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets[].name')
+  [[ "$deployment_secret" == "my-preexisting-secret" ]]
+
+  local job_secret
+  job_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Job" and .metadata.name == "deploy-ske-deployment") | .spec.template.spec.imagePullSecrets[].name')
+  [[ "$job_secret" == "my-preexisting-secret" ]]
+}
+
+# --- operator-config configmap ---
+
+@test "operator-config: pullSecret reflects imagePullSecret value" {
+  run helm_ske_operator \
+    --set imageRegistry.imagePullSecret=my-custom-secret \
+    --set skeLicense="abc123"
+  [ "$status" -eq 0 ]
+
+  local pull_secret
+  pull_secret=$(printf '%s\n' "$output" | \
+    yq 'select(.kind == "ConfigMap" and .metadata.name == "ske-operator") | .data.config' | \
+    yq '.imageRegistry.pullSecret')
+  [[ "$pull_secret" == "my-custom-secret" ]]
+}
+
+@test "operator-config: pullSecret is empty when imagePullSecret is empty" {
+  run helm_ske_operator \
+    --set imageRegistry.imagePullSecret="" \
+    --set skeLicense="abc123"
+  [ "$status" -eq 0 ]
+
+  local pull_secret
+  pull_secret=$(printf '%s\n' "$output" | \
+    yq 'select(.kind == "ConfigMap" and .metadata.name == "ske-operator") | .data.config' | \
+    yq '.imageRegistry.pullSecret')
+  [[ -z "$pull_secret" ]]
+}

--- a/tests/ske-operator/image-pull-secret-tests.bats
+++ b/tests/ske-operator/image-pull-secret-tests.bats
@@ -2,65 +2,14 @@
 
 load helpers
 
-# --- secret creation ---
+# ---------------------------------------------------------------------------
+# Scenario 1: no pull secret (managePullSecret: false, imagePullSecret unset)
+# The chart creates no secret and injects no imagePullSecrets anywhere.
+# ---------------------------------------------------------------------------
 
-@test "skeLicense set: registry secret is created with default imagePullSecret name" {
+@test "scenario 1: no pull secret: no secret created" {
   run helm_ske_operator \
-    --set skeLicense="abc123"
-  [ "$status" -eq 0 ]
-
-  local secret_name
-  secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .type == "kubernetes.io/dockerconfigjson") | .metadata.name')
-  [[ "$secret_name" == "syntasso-registry" ]]
-}
-
-@test "skeLicense set: registry secret uses custom imagePullSecret name" {
-  run helm_ske_operator \
-    --set skeLicense="abc123" \
-    --set imageRegistry.imagePullSecret=myorg-secret
-  [ "$status" -eq 0 ]
-
-  local secret_name
-  secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .type == "kubernetes.io/dockerconfigjson") | .metadata.name')
-  [[ "$secret_name" == "myorg-secret" ]]
-}
-
-@test "skeLicense empty: registry secret is not created" {
-  run helm_ske_operator \
-    --set skeLicense=""
-  [ "$status" -eq 0 ]
-
-  local secret_name
-  secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .type == "kubernetes.io/dockerconfigjson") | .metadata.name')
-  [[ -z "$secret_name" ]]
-}
-
-@test "createRegistrySecret: false: registry secret is not created even when skeLicense is set" {
-  run helm_ske_operator \
-    --set skeLicense="abc123" \
-    --set imageRegistry.createRegistrySecret=false
-  [ "$status" -eq 0 ]
-
-  local secret_name
-  secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .type == "kubernetes.io/dockerconfigjson") | .metadata.name')
-  [[ -z "$secret_name" ]]
-}
-
-@test "createRegistrySecret: false: registry secret is not created when imagePullSecret is also custom" {
-  run helm_ske_operator \
-    --set skeLicense="abc123" \
-    --set imageRegistry.imagePullSecret=my-preexisting-secret \
-    --set imageRegistry.createRegistrySecret=false
-  [ "$status" -eq 0 ]
-
-  local secret_name
-  secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .type == "kubernetes.io/dockerconfigjson") | .metadata.name')
-  [[ -z "$secret_name" ]]
-}
-
-@test "imagePullSecret empty: registry secret is not created even when skeLicense is set" {
-  run helm_ske_operator \
-    --set skeLicense="abc123" \
+    --set skeLicense="" \
     --set imageRegistry.imagePullSecret=""
   [ "$status" -eq 0 ]
 
@@ -69,64 +18,10 @@ load helpers
   [[ -z "$secret_name" ]]
 }
 
-# --- imagePullSecrets on workloads ---
-
-@test "imagePullSecret set: operator deployment references it" {
+@test "scenario 1: no pull secret: no imagePullSecrets on deployment" {
   run helm_ske_operator \
-    --set imageRegistry.imagePullSecret=syntasso-registry \
-    --set skeLicense="abc123"
-  [ "$status" -eq 0 ]
-
-  local pull_secret
-  pull_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets[].name')
-  [[ "$pull_secret" == *"syntasso-registry"* ]]
-}
-
-@test "imagePullSecret set: deploy-ske-deployment job references it" {
-  run helm_ske_operator \
-    --set imageRegistry.imagePullSecret=syntasso-registry \
-    --set skeLicense="abc123"
-  [ "$status" -eq 0 ]
-
-  local pull_secret
-  pull_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Job" and .metadata.name == "deploy-ske-deployment") | .spec.template.spec.imagePullSecrets[].name')
-  [[ "$pull_secret" == "syntasso-registry" ]]
-}
-
-@test "imagePullSecret set: backstage job references it" {
-  run helm_ske_operator \
-    --set imageRegistry.imagePullSecret=syntasso-registry \
-    --set skeLicense="abc123" \
-    --set backstageIntegration.enabled=true \
-    --set backstageIntegration.version=v0.6.0
-  [ "$status" -eq 0 ]
-
-  local pull_secret
-  pull_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Job" and .metadata.name == "deploy-backstage-integration") | .spec.template.spec.imagePullSecrets[].name')
-  [[ "$pull_secret" == "syntasso-registry" ]]
-}
-
-@test "imagePullSecret set: cortex job references it" {
-  run helm_ske_operator \
-    --set imageRegistry.imagePullSecret=syntasso-registry \
-    --set skeLicense="abc123" \
-    --set cortexIntegration.enabled=true \
-    --set cortexIntegration.config.integrationAlias=test \
-    --set cortexIntegration.config.provider=github \
-    --set cortexIntegration.config.repositoryName=test/repo \
-    --set cortexIntegration.config.token=mytoken \
-    --set cortexIntegration.config.url=https://cortex.example.com
-  [ "$status" -eq 0 ]
-
-  local pull_secret
-  pull_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Job" and .metadata.name == "deploy-cortex-integration") | .spec.template.spec.imagePullSecrets[].name')
-  [[ "$pull_secret" == "syntasso-registry" ]]
-}
-
-@test "imagePullSecret empty: no imagePullSecrets on operator deployment" {
-  run helm_ske_operator \
-    --set imageRegistry.imagePullSecret="" \
-    --set skeLicense="abc123"
+    --set skeLicense="" \
+    --set imageRegistry.imagePullSecret=""
   [ "$status" -eq 0 ]
 
   local pull_secrets
@@ -134,10 +29,10 @@ load helpers
   [[ -z "$pull_secrets" ]]
 }
 
-@test "imagePullSecret empty: no imagePullSecrets on any job" {
+@test "scenario 1: no pull secret: no imagePullSecrets on any job" {
   run helm_ske_operator \
+    --set skeLicense="" \
     --set imageRegistry.imagePullSecret="" \
-    --set skeLicense="abc123" \
     --set backstageIntegration.enabled=true \
     --set backstageIntegration.version=v0.6.0 \
     --set cortexIntegration.enabled=true \
@@ -153,48 +48,186 @@ load helpers
   [[ -z "$pull_secrets" ]]
 }
 
-# --- createRegistrySecret: false still injects the secret name into workloads ---
+@test "scenario 1: no pull secret: operator-config pullSecret is empty" {
+  run helm_ske_operator \
+    --set skeLicense="" \
+    --set imageRegistry.imagePullSecret=""
+  [ "$status" -eq 0 ]
 
-@test "createRegistrySecret: false: workloads still reference the imagePullSecret name" {
+  local pull_secret
+  pull_secret=$(ske_operator_config "$output" | yq '.imageRegistry.pullSecret')
+  [[ -z "$pull_secret" ]]
+}
+
+@test "scenario 1: managePullSecret false with skeLicense: no secret created, no injection" {
   run helm_ske_operator \
     --set skeLicense="abc123" \
-    --set imageRegistry.imagePullSecret=my-preexisting-secret \
-    --set imageRegistry.createRegistrySecret=false
+    --set imageRegistry.managePullSecret=false
   [ "$status" -eq 0 ]
 
-  local deployment_secret
-  deployment_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets[].name')
-  [[ "$deployment_secret" == "my-preexisting-secret" ]]
+  local secret_name
+  secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .type == "kubernetes.io/dockerconfigjson") | .metadata.name')
+  [[ -z "$secret_name" ]]
 
-  local job_secret
-  job_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Job" and .metadata.name == "deploy-ske-deployment") | .spec.template.spec.imagePullSecrets[].name')
-  [[ "$job_secret" == "my-preexisting-secret" ]]
+  local pull_secrets
+  pull_secrets=$(printf '%s\n' "$output" | yq 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets[].name')
+  [[ -z "$pull_secrets" ]]
 }
 
-# --- operator-config configmap ---
+# ---------------------------------------------------------------------------
+# Scenario 2: pre-created secret (managePullSecret: false, imagePullSecret set)
+# The chart injects the given name everywhere and does not create a secret.
+# ---------------------------------------------------------------------------
 
-@test "operator-config: pullSecret reflects imagePullSecret value" {
+@test "scenario 2: managePullSecret false, imagePullSecret set: no secret created" {
   run helm_ske_operator \
-    --set imageRegistry.imagePullSecret=my-custom-secret \
+    --set skeLicense="" \
+    --set imageRegistry.imagePullSecret=my-secret
+  [ "$status" -eq 0 ]
+
+  local secret_name
+  secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .type == "kubernetes.io/dockerconfigjson") | .metadata.name')
+  [[ -z "$secret_name" ]]
+}
+
+@test "scenario 2: managePullSecret false, imagePullSecret set: operator deployment references it" {
+  run helm_ske_operator \
+    --set skeLicense="" \
+    --set imageRegistry.imagePullSecret=my-secret
+  [ "$status" -eq 0 ]
+
+  local pull_secret
+  pull_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets[].name')
+  [[ "$pull_secret" == "my-secret" ]]
+}
+
+@test "scenario 2: managePullSecret false, imagePullSecret set: all jobs reference it" {
+  run helm_ske_operator \
+    --set skeLicense="" \
+    --set imageRegistry.imagePullSecret=my-secret \
+    --set backstageIntegration.enabled=true \
+    --set backstageIntegration.version=v0.6.0 \
+    --set cortexIntegration.enabled=true \
+    --set cortexIntegration.config.integrationAlias=test \
+    --set cortexIntegration.config.provider=github \
+    --set cortexIntegration.config.repositoryName=test/repo \
+    --set cortexIntegration.config.token=mytoken \
+    --set cortexIntegration.config.url=https://cortex.example.com
+  [ "$status" -eq 0 ]
+
+  local ske_job backstage_job cortex_job
+  ske_job=$(printf '%s\n' "$output" | yq 'select(.kind == "Job" and .metadata.name == "deploy-ske-deployment") | .spec.template.spec.imagePullSecrets[].name')
+  backstage_job=$(printf '%s\n' "$output" | yq 'select(.kind == "Job" and .metadata.name == "deploy-backstage-integration") | .spec.template.spec.imagePullSecrets[].name')
+  cortex_job=$(printf '%s\n' "$output" | yq 'select(.kind == "Job" and .metadata.name == "deploy-cortex-integration") | .spec.template.spec.imagePullSecrets[].name')
+  [[ "$ske_job" == "my-secret" ]]
+  [[ "$backstage_job" == "my-secret" ]]
+  [[ "$cortex_job" == "my-secret" ]]
+}
+
+@test "scenario 2: managePullSecret false, imagePullSecret set: operator-config reflects it" {
+  run helm_ske_operator \
+    --set skeLicense="" \
+    --set imageRegistry.imagePullSecret=my-secret
+  [ "$status" -eq 0 ]
+
+  local pull_secret
+  pull_secret=$(ske_operator_config "$output" | yq '.imageRegistry.pullSecret')
+  [[ "$pull_secret" == "my-secret" ]]
+}
+
+@test "scenario 2: managePullSecret false with skeLicense set: no secret created, imagePullSecret injected" {
+  run helm_ske_operator \
+    --set skeLicense="abc123" \
+    --set imageRegistry.managePullSecret=false \
+    --set imageRegistry.imagePullSecret=my-preexisting-secret
+  [ "$status" -eq 0 ]
+
+  local secret_name
+  secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .type == "kubernetes.io/dockerconfigjson") | .metadata.name')
+  [[ -z "$secret_name" ]]
+
+  local pull_secret
+  pull_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets[].name')
+  [[ "$pull_secret" == "my-preexisting-secret" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Scenario 3: chart-managed secret (skeLicense set, managePullSecret unset or true)
+# The chart creates "syntasso-registry" and injects it into all workloads.
+# imagePullSecret is ignored.
+# ---------------------------------------------------------------------------
+
+@test "scenario 3: skeLicense set: creates secret named syntasso-registry" {
+  run helm_ske_operator \
+    --set skeLicense="abc123"
+  [ "$status" -eq 0 ]
+
+  local secret_name
+  secret_name=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .type == "kubernetes.io/dockerconfigjson") | .metadata.name')
+  [[ "$secret_name" == "syntasso-registry" ]]
+}
+
+@test "scenario 3: skeLicense set: operator deployment uses syntasso-registry" {
+  run helm_ske_operator \
     --set skeLicense="abc123"
   [ "$status" -eq 0 ]
 
   local pull_secret
-  pull_secret=$(printf '%s\n' "$output" | \
-    yq 'select(.kind == "ConfigMap" and .metadata.name == "ske-operator") | .data.config' | \
-    yq '.imageRegistry.pullSecret')
-  [[ "$pull_secret" == "my-custom-secret" ]]
+  pull_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets[].name')
+  [[ "$pull_secret" == "syntasso-registry" ]]
 }
 
-@test "operator-config: pullSecret is empty when imagePullSecret is empty" {
+@test "scenario 3: skeLicense set: all jobs use syntasso-registry" {
   run helm_ske_operator \
-    --set imageRegistry.imagePullSecret="" \
+    --set skeLicense="abc123" \
+    --set backstageIntegration.enabled=true \
+    --set backstageIntegration.version=v0.6.0 \
+    --set cortexIntegration.enabled=true \
+    --set cortexIntegration.config.integrationAlias=test \
+    --set cortexIntegration.config.provider=github \
+    --set cortexIntegration.config.repositoryName=test/repo \
+    --set cortexIntegration.config.token=mytoken \
+    --set cortexIntegration.config.url=https://cortex.example.com
+  [ "$status" -eq 0 ]
+
+  local ske_job backstage_job cortex_job
+  ske_job=$(printf '%s\n' "$output" | yq 'select(.kind == "Job" and .metadata.name == "deploy-ske-deployment") | .spec.template.spec.imagePullSecrets[].name')
+  backstage_job=$(printf '%s\n' "$output" | yq 'select(.kind == "Job" and .metadata.name == "deploy-backstage-integration") | .spec.template.spec.imagePullSecrets[].name')
+  cortex_job=$(printf '%s\n' "$output" | yq 'select(.kind == "Job" and .metadata.name == "deploy-cortex-integration") | .spec.template.spec.imagePullSecrets[].name')
+  [[ "$ske_job" == "syntasso-registry" ]]
+  [[ "$backstage_job" == "syntasso-registry" ]]
+  [[ "$cortex_job" == "syntasso-registry" ]]
+}
+
+@test "scenario 3: skeLicense set: imagePullSecret value is ignored" {
+  run helm_ske_operator \
+    --set skeLicense="abc123" \
+    --set imageRegistry.imagePullSecret=some-other-secret
+  [ "$status" -eq 0 ]
+
+  local pull_secret
+  pull_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Deployment") | .spec.template.spec.imagePullSecrets[].name')
+  [[ "$pull_secret" == "syntasso-registry" ]]
+}
+
+@test "scenario 3: skeLicense set: operator-config pullSecret is syntasso-registry" {
+  run helm_ske_operator \
     --set skeLicense="abc123"
   [ "$status" -eq 0 ]
 
   local pull_secret
-  pull_secret=$(printf '%s\n' "$output" | \
-    yq 'select(.kind == "ConfigMap" and .metadata.name == "ske-operator") | .data.config' | \
-    yq '.imageRegistry.pullSecret')
-  [[ -z "$pull_secret" ]]
+  pull_secret=$(ske_operator_config "$output" | yq '.imageRegistry.pullSecret')
+  [[ "$pull_secret" == "syntasso-registry" ]]
+}
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+@test "managePullSecret: true without skeLicense: helm template fails with clear error" {
+  run helm_ske_operator \
+    --set skeLicense="" \
+    --set imageRegistry.managePullSecret=true
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"managePullSecret is true but skeLicense is not set"* ]]
 }

--- a/tests/ske-operator/release-storage-tests.bats
+++ b/tests/ske-operator/release-storage-tests.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "releaseStorage.releasesPath: renders releasesPath in config" {
+  run helm_ske_operator \
+    --set-string releaseStorage.releasesPath=platform-releases
+  [ "$status" -eq 0 ]
+
+  local config
+  config="$(ske_operator_config "$output")"
+
+  [[ $(printf '%s\n' "$config" | yq '.releaseStorage.releasesPath') == "platform-releases" ]]
+  [[ $(printf '%s\n' "$config" | yq '.releaseStorage.path') == "null" ]]
+}
+
+@test "releaseStorage.path: legacy key still renders in config" {
+  run helm_ske_operator \
+    --set-string releaseStorage.releasesPath= \
+    --set-string releaseStorage.path=legacy-path
+  [ "$status" -eq 0 ]
+
+  local config
+  config="$(ske_operator_config "$output")"
+
+  [[ $(printf '%s\n' "$config" | yq '.releaseStorage.path') == "legacy-path" ]]
+  [[ $(printf '%s\n' "$config" | yq '.releaseStorage.releasesPath') == "null" ]]
+}
+
+@test "releaseStorage.path and releaseStorage.releasesPath set together: helm template fails" {
+  run helm_ske_operator \
+    --set-string releaseStorage.path=legacy-path \
+    --set-string releaseStorage.releasesPath=new-path
+
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"releaseStorage.path and releaseStorage.releasesPath are mutually exclusive"* ]]
+}

--- a/tests/ske-operator/tls-tests.bats
+++ b/tests/ske-operator/tls-tests.bats
@@ -1,0 +1,76 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "certManager disabled: both TLS secrets rendered when no secretRefs set" {
+  run helm_ske_operator \
+    --set skeDeployment.tlsConfig.certManager.disabled=true \
+    --set-string skeDeployment.tlsConfig.webhookCACert=ca \
+    --set-string skeDeployment.tlsConfig.webhookTLSCert=cert \
+    --set-string skeDeployment.tlsConfig.webhookTLSKey=key \
+    --set-string skeDeployment.tlsConfig.metricsServerCACert=ca \
+    --set-string skeDeployment.tlsConfig.metricsServerTLSCert=cert \
+    --set-string skeDeployment.tlsConfig.metricsServerTLSKey=key
+  [ "$status" -eq 0 ]
+
+  local tls_secrets
+  tls_secrets=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret") | .metadata.name')
+  [[ "$tls_secrets" == *"custom-kratix-platform-serving-cert"* ]]
+  [[ "$tls_secrets" == *"custom-kratix-platform-metrics-server-cert"* ]]
+}
+
+@test "certManager disabled + webhookTLSSecretRef: webhook secret not created, deployment-config uses given name" {
+  run helm_ske_operator \
+    --set skeDeployment.tlsConfig.certManager.disabled=true \
+    --set skeDeployment.tlsConfig.webhookTLSSecretRef.name=my-webhook-tls-secret \
+    --set-string skeDeployment.tlsConfig.metricsServerCACert=ca \
+    --set-string skeDeployment.tlsConfig.metricsServerTLSCert=cert \
+    --set-string skeDeployment.tlsConfig.metricsServerTLSKey=key
+  [ "$status" -eq 0 ]
+
+  local tls_secrets
+  tls_secrets=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret") | .metadata.name')
+  [[ "$tls_secrets" != *"my-webhook-tls-secret"* ]]
+  [[ "$tls_secrets" == *"custom-kratix-platform-metrics-server-cert"* ]]
+
+  local cert_secret_name
+  cert_secret_name=$(ske_deployment_config "$output" | yq '.spec.tlsConfig.certSecretName')
+  [[ "$cert_secret_name" == "my-webhook-tls-secret" ]]
+}
+
+@test "certManager disabled + metricsServerTLSSecretRef: metrics secret not created, deployment-config uses given name" {
+  run helm_ske_operator \
+    --set skeDeployment.tlsConfig.certManager.disabled=true \
+    --set-string skeDeployment.tlsConfig.webhookCACert=ca \
+    --set-string skeDeployment.tlsConfig.webhookTLSCert=cert \
+    --set-string skeDeployment.tlsConfig.webhookTLSKey=key \
+    --set skeDeployment.tlsConfig.metricsServerTLSSecretRef.name=my-metrics-tls-secret
+  [ "$status" -eq 0 ]
+
+  local tls_secrets
+  tls_secrets=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret") | .metadata.name')
+  [[ "$tls_secrets" == *"custom-kratix-platform-serving-cert"* ]]
+  [[ "$tls_secrets" != *"my-metrics-tls-secret"* ]]
+
+  local metrics_cert_secret_name
+  metrics_cert_secret_name=$(ske_deployment_config "$output" | yq '.spec.tlsConfig.metricsServerCertSecretName')
+  [[ "$metrics_cert_secret_name" == "my-metrics-tls-secret" ]]
+}
+
+@test "certManager disabled + both secretRefs: neither TLS secret created, deployment-config uses given names" {
+  run helm_ske_operator \
+    --set skeDeployment.tlsConfig.certManager.disabled=true \
+    --set skeDeployment.tlsConfig.webhookTLSSecretRef.name=my-webhook-tls-secret \
+    --set skeDeployment.tlsConfig.metricsServerTLSSecretRef.name=my-metrics-tls-secret
+  [ "$status" -eq 0 ]
+
+  local tls_secrets
+  tls_secrets=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret") | .metadata.name')
+  [[ "$tls_secrets" != *"my-webhook-tls-secret"* ]]
+  [[ "$tls_secrets" != *"my-metrics-tls-secret"* ]]
+
+  local deployment_config
+  deployment_config="$(ske_deployment_config "$output")"
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.tlsConfig.certSecretName') == "my-webhook-tls-secret" ]]
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.tlsConfig.metricsServerCertSecretName') == "my-metrics-tls-secret" ]]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -25,50 +25,34 @@ global:
   # only set to true for dev or testing environments
   #   deleteOnUninstall: false
 
-# Your SKE License Key. 
-# Used wherever the license is required (e.g. pull secret creation). Setting
-# this field alone is sufficient for the most common installation. See
-# imageRegistry.managePullSecret below.
-skeLicense: "my-ske-license"
+# Your SKE License Key.
+# To avoid storing the license in plain text (e.g. for GitOps workflows), omit this field and
+# instead pre-create a kubernetes.io/dockerconfigjson Secret manually, then set
+# imageRegistry.imagePullSecret to its name. The chart will skip creating the pull secret.
+skeLicense: ""
 
 # Configuration for the Registry and Manifests
 # Update these values if you are using a custom registry or bucket
 # If using Syntasso Enterprise defaults, no changes are required
 imageRegistry:
-  # The host registry to pull the images from.
-  # Syntasso Enterprise images are hosted on ghcr.io.
-  # Update this value if you are mirroring images to a private registry.
+  # The host registry to pull the images from
+  # Syntasso Enterprise images are hosted on ghcr.io
+  # If you are using a custom registry, update this value to your registry host
   host: "ghcr.io"
+  # The name of an existing image pull secret to use instead of creating one from skeLicense above.
+  # Use this for GitOps workflows to avoid storing the license in Helm values:
+  # pre-create a kubernetes.io/dockerconfigjson Secret and set its name here.
 
-  # Pull secret configuration — three supported scenarios:
-  #
-  # 1. Chart manages the secret (DEFAULT when skeLicense is set)
-  #    The chart creates a Secret named "syntasso-registry" from skeLicense
-  #    and injects it into all workloads. No extra fields needed.
-  #
-  # 2. You manage the secret (GitOps / pre-created secret)
-  #    Pre-create a kubernetes.io/dockerconfigjson Secret yourself, then set:
-  #      imageRegistry.managePullSecret: false
-  #      imageRegistry.imagePullSecret: "<your-secret-name>"
-  #    The chart will inject that name without creating anything.
-  #
-  # 3. No pull secret (cluster-level image pull access)
-  #    Your cluster can pull images without a Secret (e.g. node-level credentials).
-  #    Set:
-  #      imageRegistry.managePullSecret: false
-  #    The chart will not create or inject any pull secret.
+  # The name of the pull secret used by all workloads to pull images.
+  # If empty or not set, no imagePullSecrets are injected and the cluster must
+  # be able to pull images without a secret.
+  imagePullSecret: ""
 
-  # Controls whether the chart creates the "syntasso-registry" Secret from
-  # skeLicense and injects it into all workloads.
-  # Default: true when skeLicense is set, false otherwise.
-  # Set to false to opt out of chart-managed pull secrets while still providing
-  # skeLicense for other features (e.g. entitlement checks).
-  #managePullSecret: true
-
-  # Name of a pre-existing kubernetes.io/dockerconfigjson Secret to inject into
-  # workloads. Only used when managePullSecret is false.
-  # Leave unset (or empty) if no pull secret is needed.
-  # imagePullSecret: "my-secret"
+  # Controls whether the chart creates the registry pull secret from skeLicense.
+  # When not set, defaults to true if skeLicense is provided, false otherwise.
+  # Set to false explicitly if you have pre-created the secret yourself and do
+  # not want the chart to manage it, even when skeLicense is also set.
+  createRegistrySecret: false
 
   skeOperatorImage:
     # The name of the SKE operator use. Update this if you are using a custom image name for the operator


### PR DESCRIPTION
 Decouple image pull secret management from `skeLicense`

* Introduces imageRegistry.managePullSecret to give users explicit control over how pull secrets are handled, independent of whether skeLicense is set. 
*  Three scenarios are now supported and documented in `values.yaml`:
    1. No pull secret: set `managePullSecret: false` (or leave `skeLicense` unset). Nothing is created or injected.
    2. Pre-created secret: set `managePullSecret: false` + `imagePullSecret: <name>`. The chart injects the given name without creating anything.
    3. Chart-managed secret (default when `skeLicense` is set): the chart creates `syntasso-registry` from `skeLicense` and injects it into all workloads. The secret name is fixed and `imagePullSecret` is ignored.