### PR TITLE
feat: allow template volume and volumeMounts for ske deployment

### DIFF
--- a/ske-operator/templates/ske-deployment-config.yaml
+++ b/ske-operator/templates/ske-deployment-config.yaml
@@ -30,6 +30,14 @@ data:
         affinity:
 {{- toYaml . | nindent 10 }}
         {{- end }}
+        {{- with $dc.volumes }}
+        volumes:
+{{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with $dc.volumeMounts }}
+        volumeMounts:
+{{- toYaml . | nindent 10 }}
+        {{- end }}
       {{- end }}
       tlsConfig:
         {{- if ( .tlsConfig.certManager.disabled | default false ) }}

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -172,6 +172,15 @@ skeDeployment:
     #               operator: In
     #               values:
     #                 - amd64
+    volumes: []
+    # volumes:
+    #   - name: plugins
+    #     emptyDir: {}
+    volumeMounts: []
+    # volumeMounts:
+    #   - mountPath: /usr/local/libexec/vault
+    #     name: plugins
+    #     readOnly: true
   tlsConfig:
     certManager:
       disabled: false

--- a/tests/ske-operator/deployment-config-tests.bats
+++ b/tests/ske-operator/deployment-config-tests.bats
@@ -2,7 +2,7 @@
 
 load helpers
 
-@test "deploymentConfig.resources rendered, nodeSelector/tolerations/affinity absent" {
+@test "deploymentConfig.resources rendered, nodeSelector/tolerations/affinity/volumes/volumeMounts absent" {
   run helm_ske_operator
   [ "$status" -eq 0 ]
 
@@ -13,6 +13,8 @@ load helpers
   [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.nodeSelector') == "null" ]]
   [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.tolerations') == "null" ]]
   [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.affinity') == "null" ]]
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.volumes') == "null" ]]
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.volumeMounts') == "null" ]]
 }
 
 @test "deploymentConfig: not rendered when no fields are set" {
@@ -71,7 +73,35 @@ load helpers
   [[ $(printf '%s\n' "$deployment_config" | yq "${match_expr}.values[0]") == "amd64" ]]
 }
 
-@test "resources, nodeSelector, tolerations and affinity: all rendered under deploymentConfig when set together" {
+@test "volumes: rendered under deploymentConfig when set" {
+  run helm_ske_operator \
+    --set 'skeDeployment.deploymentConfig.volumes[0].name=plugins' \
+    --set 'skeDeployment.deploymentConfig.volumes[0].emptyDir.sizeLimit=1Gi'
+  [ "$status" -eq 0 ]
+
+  local deployment_config
+  deployment_config="$(ske_deployment_config "$output")"
+
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.volumes[0].name') == "plugins" ]]
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.volumes[0].emptyDir.sizeLimit') == "1Gi" ]]
+}
+
+@test "volumeMounts: rendered under deploymentConfig when set" {
+  run helm_ske_operator \
+    --set 'skeDeployment.deploymentConfig.volumeMounts[0].mountPath=/usr/local/libexec/vault' \
+    --set 'skeDeployment.deploymentConfig.volumeMounts[0].name=plugins' \
+    --set 'skeDeployment.deploymentConfig.volumeMounts[0].readOnly=true'
+  [ "$status" -eq 0 ]
+
+  local deployment_config
+  deployment_config="$(ske_deployment_config "$output")"
+
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.volumeMounts[0].mountPath') == "/usr/local/libexec/vault" ]]
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.volumeMounts[0].name') == "plugins" ]]
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.volumeMounts[0].readOnly') == "true" ]]
+}
+
+@test "all deploymentConfig keys: rendered together when set" {
   run helm_ske_operator \
     --set 'skeDeployment.deploymentConfig.nodeSelector.kubernetes\.io/os=linux' \
     --set 'skeDeployment.deploymentConfig.tolerations[0].key=dedicated' \
@@ -80,7 +110,12 @@ load helpers
     --set 'skeDeployment.deploymentConfig.tolerations[0].effect=NoSchedule' \
     --set 'skeDeployment.deploymentConfig.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key=kubernetes.io/arch' \
     --set 'skeDeployment.deploymentConfig.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator=In' \
-    --set 'skeDeployment.deploymentConfig.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=amd64'
+    --set 'skeDeployment.deploymentConfig.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]=amd64' \
+    --set 'skeDeployment.deploymentConfig.volumes[0].name=plugins' \
+    --set 'skeDeployment.deploymentConfig.volumes[0].emptyDir.sizeLimit=1Gi' \
+    --set 'skeDeployment.deploymentConfig.volumeMounts[0].mountPath=/usr/local/libexec/vault' \
+    --set 'skeDeployment.deploymentConfig.volumeMounts[0].name=plugins' \
+    --set 'skeDeployment.deploymentConfig.volumeMounts[0].readOnly=true'
   [ "$status" -eq 0 ]
 
   local deployment_config
@@ -90,4 +125,7 @@ load helpers
   [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.nodeSelector["kubernetes.io/os"]') == "linux" ]]
   [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.tolerations[0].key') == "dedicated" ]]
   [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key') == "kubernetes.io/arch" ]]
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.volumes[0].name') == "plugins" ]]
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.volumeMounts[0].mountPath') == "/usr/local/libexec/vault" ]]
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig.volumeMounts[0].name') == "plugins" ]]
 }


### PR DESCRIPTION
## Context

relates to https://github.com/syntasso/helm-charts/issues/164

* allow templation for additional volumes and volumeMounts fields for ske deployment

depends on this PR on ske-operator to be released to work: https://github.com/syntasso/enterprise-kratix/pull/1005

Example values file:
```yaml
skeLicense: "a-license"
imageRegistry:
  managePullSecret: false
skeDeployment:
  deploymentConfig:
    volumes:
    - name: test
      emptyDir: {}
    volumeMounts:
    - mountPath: /usr/local/test000
      name: test
      readOnly: false
```
 