### PR TITLE
feat: allow setting timeoutSeconds for webhooks

### DIFF
--- a/ske-operator/templates/ske-deployment-config.yaml
+++ b/ske-operator/templates/ske-deployment-config.yaml
@@ -13,6 +13,10 @@ data:
       name: kratix
     spec:
       version: {{ .version | default "latest" }}
+{{- with .webhookConfig }}
+      webhookConfig:
+{{- toYaml . | nindent 8 }}
+{{- end }}
       {{- $dc := .deploymentConfig }}
       {{- with $dc.resources }}
       deploymentConfig:

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -181,8 +181,8 @@ skeDeployment:
     #   - mountPath: /usr/local/libexec/vault
     #     name: plugins
     #     readOnly: true
-  webhookConfig:
-    timeoutSeconds: 10
+  # webhookConfig:
+  #   timeoutSeconds: 10
   tlsConfig:
     certManager:
       disabled: false

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -181,6 +181,8 @@ skeDeployment:
     #   - mountPath: /usr/local/libexec/vault
     #     name: plugins
     #     readOnly: true
+  webhookConfig:
+    timeoutSeconds: 10
   tlsConfig:
     certManager:
       disabled: false

--- a/tests/ske-operator/deployment-config-tests.bats
+++ b/tests/ske-operator/deployment-config-tests.bats
@@ -28,38 +28,6 @@ load helpers
   [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig') == "null" ]]
 }
 
-@test "webhookConfig: not rendered by default" {
-  run helm_ske_operator
-  [ "$status" -eq 0 ]
-
-  local deployment_config
-  deployment_config="$(ske_deployment_config "$output")"
-
-  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.webhookConfig') == "null" ]]
-}
-
-@test "webhookConfig: timeoutSeconds rendered with override value" {
-  run helm_ske_operator \
-    --set 'skeDeployment.webhookConfig.timeoutSeconds=5'
-  [ "$status" -eq 0 ]
-
-  local deployment_config
-  deployment_config="$(ske_deployment_config "$output")"
-
-  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.webhookConfig.timeoutSeconds') == "5" ]]
-}
-
-@test "webhookConfig: not rendered when unset" {
-  run helm_ske_operator \
-    --set 'skeDeployment.webhookConfig=null'
-  [ "$status" -eq 0 ]
-
-  local deployment_config
-  deployment_config="$(ske_deployment_config "$output")"
-
-  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.webhookConfig') == "null" ]]
-}
-
 @test "nodeSelector: rendered under deploymentConfig when set" {
   run helm_ske_operator \
     --set 'skeDeployment.deploymentConfig.nodeSelector.kubernetes\.io/os=linux'

--- a/tests/ske-operator/deployment-config-tests.bats
+++ b/tests/ske-operator/deployment-config-tests.bats
@@ -28,6 +28,38 @@ load helpers
   [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig') == "null" ]]
 }
 
+@test "webhookConfig: timeoutSeconds rendered with default value" {
+  run helm_ske_operator
+  [ "$status" -eq 0 ]
+
+  local deployment_config
+  deployment_config="$(ske_deployment_config "$output")"
+
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.webhookConfig.timeoutSeconds') == "10" ]]
+}
+
+@test "webhookConfig: timeoutSeconds rendered with override value" {
+  run helm_ske_operator \
+    --set 'skeDeployment.webhookConfig.timeoutSeconds=5'
+  [ "$status" -eq 0 ]
+
+  local deployment_config
+  deployment_config="$(ske_deployment_config "$output")"
+
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.webhookConfig.timeoutSeconds') == "5" ]]
+}
+
+@test "webhookConfig: not rendered when unset" {
+  run helm_ske_operator \
+    --set 'skeDeployment.webhookConfig=null'
+  [ "$status" -eq 0 ]
+
+  local deployment_config
+  deployment_config="$(ske_deployment_config "$output")"
+
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.webhookConfig') == "null" ]]
+}
+
 @test "nodeSelector: rendered under deploymentConfig when set" {
   run helm_ske_operator \
     --set 'skeDeployment.deploymentConfig.nodeSelector.kubernetes\.io/os=linux'

--- a/tests/ske-operator/deployment-config-tests.bats
+++ b/tests/ske-operator/deployment-config-tests.bats
@@ -28,14 +28,14 @@ load helpers
   [[ $(printf '%s\n' "$deployment_config" | yq '.spec.deploymentConfig') == "null" ]]
 }
 
-@test "webhookConfig: timeoutSeconds rendered with default value" {
+@test "webhookConfig: not rendered by default" {
   run helm_ske_operator
   [ "$status" -eq 0 ]
 
   local deployment_config
   deployment_config="$(ske_deployment_config "$output")"
 
-  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.webhookConfig.timeoutSeconds') == "10" ]]
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.webhookConfig') == "null" ]]
 }
 
 @test "webhookConfig: timeoutSeconds rendered with override value" {

--- a/tests/ske-operator/webhook-config-tests.bats
+++ b/tests/ske-operator/webhook-config-tests.bats
@@ -1,0 +1,24 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "webhookConfig: not rendered by default" {
+  run helm_ske_operator
+  [ "$status" -eq 0 ]
+
+  local deployment_config
+  deployment_config="$(ske_deployment_config "$output")"
+
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.webhookConfig') == "null" ]]
+}
+
+@test "webhookConfig: timeoutSeconds rendered with override value" {
+  run helm_ske_operator \
+    --set 'skeDeployment.webhookConfig.timeoutSeconds=5'
+  [ "$status" -eq 0 ]
+
+  local deployment_config
+  deployment_config="$(ske_deployment_config "$output")"
+
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.webhookConfig.timeoutSeconds') == "5" ]]
+}


### PR DESCRIPTION
The default time out for webhooks in K8s is 10s. 

This PR allows us to set a different timeout for both validation and mutating webhooks, as part of the work done in #[1034](https://github.com/syntasso/enterprise-kratix/pull/1034). Valid values are from 1-30s.

This has been tested manually with helm template as well as having automated tests