### PR TITLE
fix: do not render path when it's not set

### DIFF
--- a/kratix/templates/statestores.yaml
+++ b/kratix/templates/statestores.yaml
@@ -9,7 +9,9 @@ metadata:
     helm.sh/hook: "post-install,post-upgrade"
     helm.sh/hook-weight: "5"
 spec:
+  {{- if .path }}
   path: {{ .path }}
+  {{- end }}
   secretRef:
     name: {{ .secretRef.name }}
     namespace: {{ .namespace }}


### PR DESCRIPTION
## Context

This fixes issue:
```
❯ helm install kratix kratix/ -f test-values.yaml
Error: INSTALLATION FAILED: failed post-install: warning: Hook post-install kratix/templates/statestores.yaml failed: server-side apply failed for object /default platform.kratix.io/v1alpha1, Kind=BucketStateStore: BucketStateStore.platform.kratix.io "default" is invalid: spec.path: Invalid value: "null": spec.path in body must be of type string: "null"
```

When path are not set, before the PR, helm would template `spec.path` with empty value:
```
# Source: kratix/templates/statestores.yaml
apiVersion: platform.kratix.io/v1alpha1
kind: BucketStateStore
metadata:
  name: default
  annotations:
    helm.sh/hook: "post-install,post-upgrade"
    helm.sh/hook-weight: "5"
spec:
  path:
  secretRef:
    name: blah
    namespace: default
  bucketName: kratix
  insecure: true
```

This PR fixes that. With the same values, it will now skip path when it's not set:
```
# Source: kratix/templates/statestores.yaml
apiVersion: platform.kratix.io/v1alpha1
kind: BucketStateStore
metadata:
  name: default
  annotations:
    helm.sh/hook: "post-install,post-upgrade"
    helm.sh/hook-weight: "5"
spec:
  secretRef:
    name: blah
    namespace: default
  bucketName: kratix
  insecure: true
```