### PR TITLE
chore: enable Dependabot PRs for github-actions version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,10 @@
 version: 2
 updates:
-  # Version updates disabled — security-only to reduce noise.
-  # open-pull-requests-limit: 0 suppresses routine version bumps; Dependabot security alerts
-  # bypass this limit and still open individual PRs for CVEs.
-  # Re-enable by removing open-pull-requests-limit once ready to tackle version catch-up.
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
       day: monday
-    open-pull-requests-limit: 0
     groups:
       github-actions:
         patterns: ["*"]


### PR DESCRIPTION
Removes `open-pull-requests-limit: 0` from the github-actions Dependabot config so version bump PRs are opened automatically.

**Why now:** Node.js 20 actions are deprecated — hard removal September 16th 2026, warnings from June 16th. Dependabot will open a grouped PR to bump all actions to Node.js 24 compatible versions.

Security CVE PRs were never affected by this limit — they still open regardless.

Part of syntasso/enterprise-kratix#1024.