### PR TITLE
fix: resolve ske-operator test suite flakiness and performance

### DIFF
--- a/.github/workflows/run-ci.yaml
+++ b/.github/workflows/run-ci.yaml
@@ -98,7 +98,7 @@ jobs:
       - name: Install Ginkgo CLI
         if: ${{ (github.event_name == 'push' && steps.changes.outputs.ske-operator == 'true') || (github.event_name == 'workflow_dispatch' && inputs.helm_chart_name == 'ske-operator') }}
         run: |
-          go install github.com/onsi/ginkgo/v2/ginkgo@latest
+          go install github.com/onsi/ginkgo/v2/ginkgo@v2.21.0
         env:
           PATH: ${{ env.PATH }}:/home/runner/go/bin
 

--- a/.github/workflows/run-ci.yaml
+++ b/.github/workflows/run-ci.yaml
@@ -49,7 +49,7 @@ on:
 jobs:
   test:
     if: ${{ !startsWith(github.ref, 'refs/tags/') && (github.event_name == 'push' || github.event_name == 'workflow_dispatch') && inputs.chart_tag == '' }}
-    runs-on: sprinters:aws:us-east-1:ubuntu-latest:c7i.large
+    runs-on: sprinters:aws:us-east-1:ubuntu-latest:m7i.xlarge
     env:
       GITHUB_EVENT_NAME: ${{ github.event_name }}
       GITHUB_REF: ${{ github.ref }}
@@ -94,6 +94,25 @@ jobs:
         with:
           version: "v0.20.0"
           cluster_name: "platform"
+
+      - name: Pre-load images into Kind
+        if: ${{ (github.event_name == 'push' && steps.changes.outputs.ske-operator == 'true') || (github.event_name == 'workflow_dispatch' && inputs.helm_chart_name == 'ske-operator') }}
+        run: |
+          docker pull quay.io/jetstack/cert-manager-controller:v1.15.0
+          docker pull quay.io/jetstack/cert-manager-webhook:v1.15.0
+          docker pull quay.io/jetstack/cert-manager-cainjector:v1.15.0
+          kind load docker-image quay.io/jetstack/cert-manager-controller:v1.15.0 --name platform
+          kind load docker-image quay.io/jetstack/cert-manager-webhook:v1.15.0 --name platform
+          kind load docker-image quay.io/jetstack/cert-manager-cainjector:v1.15.0 --name platform
+
+          APP_VERSION=$(grep '^appVersion:' ske-operator/Chart.yaml | awk '{print $2}' | tr -d '"')
+          echo "$SKE_LICENSE_TOKEN" | docker login ghcr.io -u syntasso-pkg --password-stdin
+          docker pull ghcr.io/syntasso/ske-operator:${APP_VERSION}
+          docker pull ghcr.io/syntasso/ske-platform:${APP_VERSION}
+          kind load docker-image ghcr.io/syntasso/ske-operator:${APP_VERSION} --name platform
+          kind load docker-image ghcr.io/syntasso/ske-platform:${APP_VERSION} --name platform
+        env:
+          SKE_LICENSE_TOKEN: ${{ secrets.SKE_LICENSE_TOKEN }}
 
       - name: Install Ginkgo CLI
         if: ${{ (github.event_name == 'push' && steps.changes.outputs.ske-operator == 'true') || (github.event_name == 'workflow_dispatch' && inputs.helm_chart_name == 'ske-operator') }}

--- a/.github/workflows/run-ci.yaml
+++ b/.github/workflows/run-ci.yaml
@@ -112,7 +112,7 @@ jobs:
       - name: Run Tests
         if: ${{ (github.event_name == 'push' && steps.changes.outputs.ske-operator == 'true') || (github.event_name == 'workflow_dispatch' && inputs.helm_chart_name == 'ske-operator') }}
         run: |
-          ginkgo -r tests/
+          ginkgo -r --timeout=2h tests/
         env:
           GH_TOKEN: ${{ secrets.CR_TOKEN }}
           SKE_LICENSE_TOKEN: ${{ secrets.SKE_LICENSE_TOKEN }}

--- a/tests/ske_operator_test.go
+++ b/tests/ske_operator_test.go
@@ -44,7 +44,7 @@ var _ = Describe("ske-operator helm chart", func() {
 
 		It("can install, upgrade and uninstall SKE successfully", func() {
 			By("installing SKE", func() {
-				run("helm", "install", "ske-operator", "--create-namespace", "../ske-operator/",
+				runLongTimeout("helm", "install", "ske-operator", "--create-namespace", "../ske-operator/",
 					"-n=kratix-platform-system", "-f=./assets/values-with-certmanager.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait")
 
 				By("creating a certificate and issuer, and use them for the webhook")
@@ -71,7 +71,7 @@ var _ = Describe("ske-operator helm chart", func() {
 
 			By("upgrading SKE", func() {
 				run("pwd")
-				run("helm", "upgrade", "ske-operator", "../ske-operator/", "-n=kratix-platform-system",
+				runLongTimeout("helm", "upgrade", "ske-operator", "../ske-operator/", "-n=kratix-platform-system",
 					"-f=./assets/values-with-upgrade.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait")
 
 				By("upgrading SKE version", func() {
@@ -100,7 +100,7 @@ var _ = Describe("ske-operator helm chart", func() {
 
 			By("uninstalling SKE", func() {
 				run("pwd")
-				run("helm", "uninstall", "ske-operator", "-n=kratix-platform-system", "--wait")
+				runLongTimeout("helm", "uninstall", "ske-operator", "-n=kratix-platform-system", "--wait")
 
 				By("deleting operator", func() {
 					Expect(run("kubectl", context, "get", "deployments", "ske-operator-controller-manager", "--ignore-not-found")).To(BeEmpty())
@@ -141,7 +141,7 @@ var _ = Describe("ske-operator helm chart", func() {
 
 		AfterEach(func() {
 			run("kubectl", context, "delete", "kratixes", "kratix", "--timeout="+formatTimeout(kubectlTimeout))
-			run("helm", "uninstall", "ske-operator", "-n=kratix-platform-system", "--wait")
+			runLongTimeout("helm", "uninstall", "ske-operator", "-n=kratix-platform-system", "--wait")
 			runLongTimeout("kubectl", context, "delete", "namespace", "kratix-platform-system", "--timeout="+formatTimeout(kubectlLongTimeout))
 			deleteCRDs(context)
 		})
@@ -158,7 +158,7 @@ var _ = Describe("ske-operator helm chart", func() {
 				metricsTlsKey, _ := run("cat", "./metrics-tls.key")
 				metricsCa, _ := run("cat", "./metrics-ca.crt")
 
-				run("helm", "install", "ske-operator", "--create-namespace", "../ske-operator/",
+				runLongTimeout("helm", "install", "ske-operator", "--create-namespace", "../ske-operator/",
 					"-n=kratix-platform-system", "-f=./assets/values-without-certmanager.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait",
 					"--set-string", "global.skeOperator.tlsConfig.webhookTLSCert="+operatorTlsCrt,
 					"--set-string", "global.skeOperator.tlsConfig.webhookTLSKey="+operatorTlsKey,
@@ -226,7 +226,7 @@ var _ = Describe("ske-operator helm chart", func() {
 
 			When("deploying the chart", func() {
 				BeforeEach(func() {
-					run("helm", "uninstall", "ske-operator", "-n=kratix-platform-system", "--ignore-not-found", "--wait")
+					runLongTimeout("helm", "uninstall", "ske-operator", "-n=kratix-platform-system", "--ignore-not-found", "--wait")
 					run("kubectl", context, "apply", "-f=https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml")
 					run("kubectl", context, "wait", "crd/certificates.cert-manager.io", "--for=condition=established", "--timeout="+fmt.Sprintf("%ds", int(kubectlTimeout.Seconds())))
 					validateCertManagerWebhook()
@@ -239,7 +239,7 @@ var _ = Describe("ske-operator helm chart", func() {
 				})
 
 				It("creates a Backstage SKEIntegration", func() {
-					run("helm", "install", "ske-operator", "--create-namespace", "../ske-operator/",
+					runLongTimeout("helm", "install", "ske-operator", "--create-namespace", "../ske-operator/",
 						"-n=kratix-platform-system", "-f=./assets/values-with-backstage-integration-enabled.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait")
 					Eventually(func(g Gomega) {
 						runGinkgo(g, "kubectl", context, "get", "skeintegration", "backstage-integration", "-n=kratix-platform-system")
@@ -284,7 +284,7 @@ var _ = Describe("ske-operator helm chart", func() {
 
 			When("deploying the chart", func() {
 				BeforeEach(func() {
-					run("helm", "uninstall", "ske-operator", "-n=kratix-platform-system", "--ignore-not-found", "--wait")
+					runLongTimeout("helm", "uninstall", "ske-operator", "-n=kratix-platform-system", "--ignore-not-found", "--wait")
 					run("kubectl", context, "apply", "-f=https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml")
 					run("kubectl", context, "wait", "crd/certificates.cert-manager.io", "--for=condition=established", "--timeout="+fmt.Sprintf("%ds", int(kubectlTimeout.Seconds())))
 					validateCertManagerWebhook()
@@ -297,7 +297,7 @@ var _ = Describe("ske-operator helm chart", func() {
 				})
 
 				It("creates a Cortex SKEIntegration", func() {
-					run("helm", "install", "ske-operator", "--create-namespace", "../ske-operator/",
+					runLongTimeout("helm", "install", "ske-operator", "--create-namespace", "../ske-operator/",
 						"-n=kratix-platform-system", "-f=./assets/values-with-cortex-integration-enabled.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait")
 					Eventually(func(g Gomega) {
 						runGinkgo(g, "kubectl", context, "get", "skeintegration", "cortex-integration", "-n=kratix-platform-system")
@@ -358,7 +358,7 @@ var _ = Describe("ske-operator helm chart", func() {
 
 				By("installing the ske operator", func() {
 					run("pwd")
-					run("helm", "install", "ske-operator", "--create-namespace", "../ske-operator/",
+					runLongTimeout("helm", "install", "ske-operator", "--create-namespace", "../ske-operator/",
 						"-n=kratix-platform-system", "-f=./assets/values-with-delete-on-uninstall-true.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait")
 
 					run("kubectl", context, "get", "kratixes", "kratix")
@@ -367,7 +367,7 @@ var _ = Describe("ske-operator helm chart", func() {
 
 				By("uninstalling the ske operator", func() {
 					run("pwd")
-					run("helm", "uninstall", "ske-operator", "-n=kratix-platform-system", "--wait")
+					runLongTimeout("helm", "uninstall", "ske-operator", "-n=kratix-platform-system", "--wait")
 
 					By("deleting operator", func() {
 						Eventually(func() string {

--- a/tests/ske_operator_test.go
+++ b/tests/ske_operator_test.go
@@ -19,9 +19,10 @@ var (
 	timeout     = time.Second * 100
 	longTimeout = time.Second * 300
 
-	kubectlTimeout       = time.Second * 60
-	kubectlMediumTimeout = time.Second * 120
-	kubectlLongTimeout   = time.Second * 300
+	kubectlTimeout            = time.Second * 60
+	kubectlMediumTimeout      = time.Second * 120
+	kubectlLongTimeout        = time.Second * 300
+	certManagerWebhookTimeout = time.Second * 180
 
 	context = "--context=kind-platform"
 )
@@ -33,7 +34,7 @@ var _ = Describe("ske-operator helm chart", func() {
 			run("kubectl", context, "apply", "-f=https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml")
 			run("kubectl", context, "wait", "crd/certificates.cert-manager.io", "--for=condition=established", "--timeout="+formatTimeout(kubectlTimeout))
 			validateCertManagerWebhook()
-			run("kubectl", context, "wait", "--for=condition=available", "deployment/cert-manager-webhook", "-n=cert-manager")
+			run("kubectl", context, "wait", "--for=condition=available", "deployment/cert-manager-webhook", "-n=cert-manager", "--timeout="+formatTimeout(certManagerWebhookTimeout))
 		})
 
 		AfterEach(func() {
@@ -230,7 +231,7 @@ var _ = Describe("ske-operator helm chart", func() {
 					run("kubectl", context, "apply", "-f=https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml")
 					run("kubectl", context, "wait", "crd/certificates.cert-manager.io", "--for=condition=established", "--timeout="+fmt.Sprintf("%ds", int(kubectlTimeout.Seconds())))
 					validateCertManagerWebhook()
-					run("kubectl", context, "wait", "--for=condition=available", "deployment/cert-manager-webhook", "-n=cert-manager")
+					run("kubectl", context, "wait", "--for=condition=available", "deployment/cert-manager-webhook", "-n=cert-manager", "--timeout="+formatTimeout(certManagerWebhookTimeout))
 				})
 
 				AfterEach(func() {
@@ -289,7 +290,7 @@ var _ = Describe("ske-operator helm chart", func() {
 					run("kubectl", context, "apply", "-f=https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml")
 					run("kubectl", context, "wait", "crd/certificates.cert-manager.io", "--for=condition=established", "--timeout="+fmt.Sprintf("%ds", int(kubectlTimeout.Seconds())))
 					validateCertManagerWebhook()
-					run("kubectl", context, "wait", "--for=condition=available", "deployment/cert-manager-webhook", "-n=cert-manager")
+					run("kubectl", context, "wait", "--for=condition=available", "deployment/cert-manager-webhook", "-n=cert-manager", "--timeout="+formatTimeout(certManagerWebhookTimeout))
 				})
 
 				AfterEach(func() {
@@ -339,7 +340,7 @@ var _ = Describe("ske-operator helm chart", func() {
 				run("kubectl", context, "apply", "-f=https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml")
 				run("kubectl", context, "wait", "crd/certificates.cert-manager.io", "--for=condition=established", "--timeout="+fmt.Sprintf("%ds", int(kubectlTimeout.Seconds())))
 				validateCertManagerWebhook()
-				run("kubectl", context, "wait", "--for=condition=available", "deployment/cert-manager-webhook", "-n=cert-manager")
+				run("kubectl", context, "wait", "--for=condition=available", "deployment/cert-manager-webhook", "-n=cert-manager", "--timeout="+formatTimeout(certManagerWebhookTimeout))
 			})
 
 			AfterEach(func() {
@@ -415,10 +416,10 @@ var _ = Describe("ske-operator helm chart", func() {
 })
 
 func validateCertManagerWebhook() {
-	// It takes a while for the webhook to be ready, so we need to retry this with a timeout
+	// cert-manager webhook can take >100s to accept connections on slower CI runners
 	Eventually(func(g Gomega) {
 		runGinkgo(g, "kubectl", context, "apply", "-f", "assets/example-issuer.yaml", "--dry-run=server")
-	}, timeout, interval).Should(Succeed())
+	}, certManagerWebhookTimeout, interval).Should(Succeed())
 }
 
 func formatTimeout(timeout time.Duration) string {

--- a/tests/ske_operator_test.go
+++ b/tests/ske_operator_test.go
@@ -412,7 +412,14 @@ var _ = Describe("ske-operator helm chart", func() {
 })
 
 func validateCertManagerWebhook() {
-	// cert-manager webhook can take >100s to accept connections on slower CI runners
+	// wait for webhook pod to be ready before attempting connections; without this
+	// each dry-run attempt hangs for the full inner timeout (~100s) because Kind
+	// silently drops TCP connections to a service with no ready endpoints
+	run("kubectl", context, "wait", "deployment/cert-manager-webhook",
+		"-n=cert-manager", "--for=condition=available",
+		"--timeout="+formatTimeout(longTimeout))
+	// cert-manager webhook can take time to start accepting connections even after
+	// the pod is ready — retry until the dry-run succeeds
 	Eventually(func(g Gomega) {
 		runGinkgo(g, "kubectl", context, "apply", "-f", "assets/example-issuer.yaml", "--dry-run=server")
 	}, certManagerWebhookTimeout, interval).Should(Succeed())

--- a/tests/ske_operator_test.go
+++ b/tests/ske_operator_test.go
@@ -34,7 +34,6 @@ var _ = Describe("ske-operator helm chart", func() {
 			run("kubectl", context, "apply", "-f=https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml")
 			run("kubectl", context, "wait", "crd/certificates.cert-manager.io", "--for=condition=established", "--timeout="+formatTimeout(kubectlTimeout))
 			validateCertManagerWebhook()
-			run("kubectl", context, "wait", "--for=condition=available", "deployment/cert-manager-webhook", "-n=cert-manager", "--timeout="+formatTimeout(certManagerWebhookTimeout))
 		})
 
 		AfterEach(func() {
@@ -231,7 +230,6 @@ var _ = Describe("ske-operator helm chart", func() {
 					run("kubectl", context, "apply", "-f=https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml")
 					run("kubectl", context, "wait", "crd/certificates.cert-manager.io", "--for=condition=established", "--timeout="+fmt.Sprintf("%ds", int(kubectlTimeout.Seconds())))
 					validateCertManagerWebhook()
-					run("kubectl", context, "wait", "--for=condition=available", "deployment/cert-manager-webhook", "-n=cert-manager", "--timeout="+formatTimeout(certManagerWebhookTimeout))
 				})
 
 				AfterEach(func() {
@@ -290,7 +288,6 @@ var _ = Describe("ske-operator helm chart", func() {
 					run("kubectl", context, "apply", "-f=https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml")
 					run("kubectl", context, "wait", "crd/certificates.cert-manager.io", "--for=condition=established", "--timeout="+fmt.Sprintf("%ds", int(kubectlTimeout.Seconds())))
 					validateCertManagerWebhook()
-					run("kubectl", context, "wait", "--for=condition=available", "deployment/cert-manager-webhook", "-n=cert-manager", "--timeout="+formatTimeout(certManagerWebhookTimeout))
 				})
 
 				AfterEach(func() {
@@ -340,7 +337,6 @@ var _ = Describe("ske-operator helm chart", func() {
 				run("kubectl", context, "apply", "-f=https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml")
 				run("kubectl", context, "wait", "crd/certificates.cert-manager.io", "--for=condition=established", "--timeout="+fmt.Sprintf("%ds", int(kubectlTimeout.Seconds())))
 				validateCertManagerWebhook()
-				run("kubectl", context, "wait", "--for=condition=available", "deployment/cert-manager-webhook", "-n=cert-manager", "--timeout="+formatTimeout(certManagerWebhookTimeout))
 			})
 
 			AfterEach(func() {

--- a/tests/ske_operator_test.go
+++ b/tests/ske_operator_test.go
@@ -17,7 +17,7 @@ var (
 	interval = time.Second
 
 	timeout     = time.Second * 100
-	longTimeout = time.Second * 300
+	longTimeout = time.Second * 600
 
 	kubectlTimeout            = time.Second * 60
 	kubectlMediumTimeout      = time.Second * 120
@@ -45,7 +45,7 @@ var _ = Describe("ske-operator helm chart", func() {
 		It("can install, upgrade and uninstall SKE successfully", func() {
 			By("installing SKE", func() {
 				runLongTimeout("helm", "install", "ske-operator", "--create-namespace", "../ske-operator/",
-					"-n=kratix-platform-system", "-f=./assets/values-with-certmanager.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait")
+					"-n=kratix-platform-system", "-f=./assets/values-with-certmanager.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait", "--timeout=9m")
 
 				By("creating a certificate and issuer, and use them for the webhook")
 				run("kubectl", context, "get", "certificates", "ske-operator-serving-cert", "-n=kratix-platform-system")
@@ -72,7 +72,7 @@ var _ = Describe("ske-operator helm chart", func() {
 			By("upgrading SKE", func() {
 				run("pwd")
 				runLongTimeout("helm", "upgrade", "ske-operator", "../ske-operator/", "-n=kratix-platform-system",
-					"-f=./assets/values-with-upgrade.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait")
+					"-f=./assets/values-with-upgrade.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait", "--timeout=9m")
 
 				By("upgrading SKE version", func() {
 					Expect(run("kubectl", context, "get", "kratixes", "kratix", "-o", "jsonpath={.metadata.creationTimestamp}")).To(Equal(creationTimestamp))
@@ -159,7 +159,7 @@ var _ = Describe("ske-operator helm chart", func() {
 				metricsCa, _ := run("cat", "./metrics-ca.crt")
 
 				runLongTimeout("helm", "install", "ske-operator", "--create-namespace", "../ske-operator/",
-					"-n=kratix-platform-system", "-f=./assets/values-without-certmanager.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait",
+					"-n=kratix-platform-system", "-f=./assets/values-without-certmanager.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait", "--timeout=9m",
 					"--set-string", "global.skeOperator.tlsConfig.webhookTLSCert="+operatorTlsCrt,
 					"--set-string", "global.skeOperator.tlsConfig.webhookTLSKey="+operatorTlsKey,
 					"--set-string", "global.skeOperator.tlsConfig.webhookCACert="+operatorCa,
@@ -240,7 +240,7 @@ var _ = Describe("ske-operator helm chart", func() {
 
 				It("creates a Backstage SKEIntegration", func() {
 					runLongTimeout("helm", "install", "ske-operator", "--create-namespace", "../ske-operator/",
-						"-n=kratix-platform-system", "-f=./assets/values-with-backstage-integration-enabled.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait")
+						"-n=kratix-platform-system", "-f=./assets/values-with-backstage-integration-enabled.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait", "--timeout=9m")
 					Eventually(func(g Gomega) {
 						runGinkgo(g, "kubectl", context, "get", "skeintegration", "backstage-integration", "-n=kratix-platform-system")
 					}, timeout, interval).Should(Succeed())
@@ -298,7 +298,7 @@ var _ = Describe("ske-operator helm chart", func() {
 
 				It("creates a Cortex SKEIntegration", func() {
 					runLongTimeout("helm", "install", "ske-operator", "--create-namespace", "../ske-operator/",
-						"-n=kratix-platform-system", "-f=./assets/values-with-cortex-integration-enabled.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait")
+						"-n=kratix-platform-system", "-f=./assets/values-with-cortex-integration-enabled.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait", "--timeout=9m")
 					Eventually(func(g Gomega) {
 						runGinkgo(g, "kubectl", context, "get", "skeintegration", "cortex-integration", "-n=kratix-platform-system")
 					}, timeout, interval).Should(Succeed())
@@ -359,7 +359,7 @@ var _ = Describe("ske-operator helm chart", func() {
 				By("installing the ske operator", func() {
 					run("pwd")
 					runLongTimeout("helm", "install", "ske-operator", "--create-namespace", "../ske-operator/",
-						"-n=kratix-platform-system", "-f=./assets/values-with-delete-on-uninstall-true.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait")
+						"-n=kratix-platform-system", "-f=./assets/values-with-delete-on-uninstall-true.yaml", "--set-string", "skeLicense="+skeLicenseToken, "--wait", "--timeout=9m")
 
 					run("kubectl", context, "get", "kratixes", "kratix")
 					run("kubectl", context, "wait", "kratixes", "kratix", "--for=condition=KratixDeploymentReady", "--timeout="+fmt.Sprintf("%ds", int(kubectlMediumTimeout.Seconds())))

--- a/tests/ske_operator_test.go
+++ b/tests/ske_operator_test.go
@@ -17,12 +17,12 @@ var (
 	interval = time.Second
 
 	timeout     = time.Second * 100
-	longTimeout = time.Second * 600
+	longTimeout = time.Second * 1200
 
 	kubectlTimeout            = time.Second * 60
 	kubectlMediumTimeout      = time.Second * 120
 	kubectlLongTimeout        = time.Second * 300
-	certManagerWebhookTimeout = time.Second * 180
+	certManagerWebhookTimeout = time.Second * 300
 
 	context = "--context=kind-platform"
 )
@@ -37,6 +37,8 @@ var _ = Describe("ske-operator helm chart", func() {
 		})
 
 		AfterEach(func() {
+			// clean up helm release if test failed before the uninstall step
+			runLongTimeout("helm", "uninstall", "ske-operator", "-n=kratix-platform-system", "--wait", "--ignore-not-found")
 			runLongTimeout("kubectl", context, "delete", "namespace", "kratix-platform-system", "--timeout="+formatTimeout(kubectlLongTimeout), "--ignore-not-found")
 			run("kubectl", context, "delete", "-f=https://github.com/cert-manager/cert-manager/releases/download/v1.15.0/cert-manager.yaml")
 			deleteCRDs(context)
@@ -415,7 +417,7 @@ func validateCertManagerWebhook() {
 	// wait for webhook pod to be ready before attempting connections; without this
 	// each dry-run attempt hangs for the full inner timeout (~100s) because Kind
 	// silently drops TCP connections to a service with no ready endpoints
-	run("kubectl", context, "wait", "deployment/cert-manager-webhook",
+	runLongTimeout("kubectl", context, "wait", "deployment/cert-manager-webhook",
 		"-n=cert-manager", "--for=condition=available",
 		"--timeout="+formatTimeout(longTimeout))
 	// cert-manager webhook can take time to start accepting connections even after

--- a/tests/ske_operator_test.go
+++ b/tests/ske_operator_test.go
@@ -102,7 +102,7 @@ var _ = Describe("ske-operator helm chart", func() {
 
 			By("uninstalling SKE", func() {
 				run("pwd")
-				runLongTimeout("helm", "uninstall", "ske-operator", "-n=kratix-platform-system", "--wait")
+				runLongTimeout("helm", "uninstall", "ske-operator", "-n=kratix-platform-system", "--wait", "--timeout=9m")
 
 				By("deleting operator", func() {
 					Expect(run("kubectl", context, "get", "deployments", "ske-operator-controller-manager", "--ignore-not-found")).To(BeEmpty())


### PR DESCRIPTION
## TL;DR

This PR unblocks ske-operator v0.29.0 helm publish — the test suite has been failing since Jun 12, blocking the release.

**Why the tests were slow/broken:**
- `kubectl wait` for cert-manager-webhook was using `run()` (100s cap) — gexec killed it before the webhook was ready, causing x509 errors in every subsequent test
- A failed install left a `ValidatingWebhookConfiguration` behind; the next test's webhook calls hit a dead endpoint
- `ginkgo@latest` jumped from v2.21.0 → v2.31.0 on Jun 15, adding ~5min overhead
- Ginkgo's default 1h suite timeout was too short — the first two cluster tests alone took 35–50min
- `helm uninstall --wait` had no `--timeout`, letting finalizer cleanup block for up to 20min
- Cold image pulls on every run: cert-manager + ske-operator pulled fresh into Kind on every install cycle, adding 5–8min per test

**What I changed:**
- Fixed `run()` → `runLongTimeout()` for the cert-manager-webhook `kubectl wait`
- Added `helm uninstall --ignore-not-found` to AfterEach to clean up partial installs
- Pinned Ginkgo CLI to `v2.21.0`
- Set Ginkgo suite `--timeout=2h`
- Capped `helm uninstall --wait` with `--timeout=9m`
- Pre-load cert-manager + ske-operator images into Kind node before tests run
- Upgraded runner: `c7i.large` (2 vCPU / 4GB) → `m7i.xlarge` (4 vCPU / 16GB)

**Result: 60–102min failing runs → 13m 35s passing.**

---

## Root causes (detail)

### 1. `run()` gexec cap killed kubectl before cert-manager was ready
`validateCertManagerWebhook()` called `run()` for `kubectl wait deployment/cert-manager-webhook`, which has a 100s gexec cap. On slow Sprinters runners cert-manager-webhook takes >100s to become Available. gexec killed kubectl silently, the subsequent dry-run hit a service with no ready endpoints, and Kind (silently, no TCP RST) dropped the connection — so kubectl hung for the full inner timeout before failing with `x509: certificate signed by unknown authority`.

### 2. Missing `helm uninstall` in first `When` AfterEach
When a test failed mid-install, the `ValidatingWebhookConfiguration` was left behind. The next BeforeEach reinstalled cert-manager but the old VWC still pointed at a dead webhook endpoint, causing all subsequent `kubectl apply` calls to fail with x509 errors.

### 3. Ginkgo CLI `@latest` regression
Between Jun 8–15, `go install ginkgo@latest` jumped from v2.21.0 to v2.31.0. This added ~5min overhead to the suite and changed timeout handling.

### 4. Ginkgo default suite timeout (60min) too short
The suite was hitting Ginkgo's default 1-hour timeout. The first two cluster tests (cert-manager install+upgrade+uninstall cycle) alone consume 35–50min on a constrained runner.

### 5. `helm uninstall --wait` with no `--timeout`
The uninstall step in the `certManager.disabled=false` It block passed `--wait` to helm but no `--timeout`. Helm waited indefinitely for Kratix finalizers to clear — up to 20min (the gexec cap) on a CPU-constrained runner.

### 6. Cold image pulls on every run
The Sprinters c7i.large runner had no image cache. Every `helm install` pulled cert-manager (3 images, ~180MB) and ske-operator from scratch inside the Kind node's containerd, adding 5–8min per install cycle.

## Fixes

| Fix | File |
|---|---|
| `run()` → `runLongTimeout()` for `kubectl wait deployment/cert-manager-webhook` | `tests/ske_operator_test.go` |
| Add `helm uninstall --ignore-not-found` to first `When` AfterEach | `tests/ske_operator_test.go` |
| `longTimeout` 600s → 1200s; `certManagerWebhookTimeout` 180s → 300s | `tests/ske_operator_test.go` |
| Cap `helm uninstall --wait` with `--timeout=9m` | `tests/ske_operator_test.go` |
| Pin Ginkgo CLI to `v2.21.0` | `.github/workflows/run-ci.yaml` |
| Ginkgo suite timeout `--timeout=2h` | `.github/workflows/run-ci.yaml` |
| Pre-load cert-manager + ske-operator images into Kind node before tests | `.github/workflows/run-ci.yaml` |
| Runner upgrade: `c7i.large` (2 vCPU / 4GB) → `m7i.xlarge` (4 vCPU / 16GB) | `.github/workflows/run-ci.yaml` |

## Impact

| Run | Result | Duration |
|---|---|---|
| Jun 8 (last green) | ✅ pass | 11m 4s |
| Jun 12–18 (multiple runs) | ❌ fail | 60–102min (suite timeout or x509 error) |
| This PR | ✅ pass | **13m 35s** |

## Test plan

- [x] CI passed on this branch — 13m 35s, all 18 specs green
- [ ] Merge and re-dispatch `run-ci.yaml` with `helm_chart_name=ske-operator`, `update_chart_app=true` to publish ske-operator v0.29.0 helm chart