### PR TITLE
chore(ci): add blocklist, label, and step summary to dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -7,6 +7,8 @@ on:
 permissions:
   pull-requests: write
   contents: write
+  checks: read
+  statuses: read
 
 jobs:
   auto-merge:
@@ -25,9 +27,23 @@ jobs:
           TYPE="${{ steps.metadata.outputs.update-type }}"
           PREV="${{ steps.metadata.outputs.previous-version }}"
           NEW="${{ steps.metadata.outputs.new-version }}"
+          DEPS="${{ steps.metadata.outputs.dependency-names }}"
 
           echo "Update type: $TYPE"
           echo "Version: $PREV → $NEW"
+          echo "Dependencies: $DEPS"
+
+          if echo "$DEPS" | grep -qE '(^|,\s*)(k8s\.io/|sigs\.k8s\.io/controller-runtime)'; then
+            echo "result=false" >> "$GITHUB_OUTPUT"
+            echo "reason=k8s ecosystem bump — must be coordinated manually" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if echo "$DEPS" | grep -qiE '(^|,\s*)(headlamp|backstage)'; then
+            echo "result=false" >> "$GITHUB_OUTPUT"
+            echo "reason=fork dep (headlamp/backstage) — requires human review" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
 
           if [[ "$TYPE" == "version-update:semver-patch" ]]; then
             echo "result=true" >> "$GITHUB_OUTPUT"
@@ -43,6 +59,20 @@ jobs:
 
           echo "result=false" >> "$GITHUB_OUTPUT"
           echo "reason=major bump — manual review required" >> "$GITHUB_OUTPUT"
+
+      - name: Label ineligible PR
+        if: steps.eligible.outputs.result != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api repos/${{ github.repository }}/labels \
+            -f name="requires-human-review" \
+            -f color="e11d48" \
+            -f description="Dependency bump blocked from auto-merge — needs human review" \
+            2>/dev/null || true
+          gh pr edit ${{ github.event.pull_request.number }} \
+            --repo ${{ github.repository }} \
+            --add-label "requires-human-review"
 
       - name: Wait for CI checks
         if: steps.eligible.outputs.result == 'true'
@@ -82,11 +112,22 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Auto-merging: ${{ steps.eligible.outputs.reason }}"
           gh pr merge ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
             --squash \
             --delete-branch
+
+      - name: Step summary
+        if: always()
+        run: |
+          echo "## Auto-merge result" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|---|---|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Dependencies | \`${{ steps.metadata.outputs.dependency-names }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Update type | ${{ steps.metadata.outputs.update-type }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Eligible | ${{ steps.eligible.outputs.result }} |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Reason | ${{ steps.eligible.outputs.reason }} |" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Skip — not eligible
         if: steps.eligible.outputs.result != 'true'


### PR DESCRIPTION
## Summary

- Add `checks: read` / `statuses: read` permissions (missing from this repo's copy)
- Block k8s ecosystem and headlamp/backstage deps from auto-merge with `requires-human-review` label
- Add GitHub step summary as audit log (dep name, version, update type, eligibility reason)

Part of syntasso/enterprise-kratix#974.

## Test plan
- [ ] Next Dependabot PR against this repo runs through the enhanced path and step summary appears in the Actions run