### PR TITLE
fix: double auto-merge CI wait timeout to 60 min

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yaml
+++ b/.github/workflows/dependabot-auto-merge.yaml
@@ -52,7 +52,7 @@ jobs:
           sleep 20
           PR="${{ github.event.pull_request.number }}"
           REPO="${{ github.repository }}"
-          for i in $(seq 1 60); do
+          for i in $(seq 1 120); do
             STATUS=$(gh pr checks "$PR" --repo "$REPO" --json name,state 2>/dev/null || echo "[]")
             TOTAL=$(echo "$STATUS" | jq 'length')
             if [ "$TOTAL" -eq 0 ]; then
@@ -75,7 +75,7 @@ jobs:
           done
           echo "Timed out waiting for CI checks"
           exit 1
-        timeout-minutes: 35
+        timeout-minutes: 65
 
       - name: Merge
         if: steps.eligible.outputs.result == 'true'


### PR DESCRIPTION
Backstage `run-system-tests` takes 15-20min. Other repos' full suites can also exceed 30min. The previous 60-round (30-min) limit was causing false auto-merge failures where CI was green but slow.

Doubles the poll loop from 60 to 120 rounds and raises the job timeout from 35 to 65 minutes to match.