### PR TITLE
fix: deploy SKE GUI Ingress to the same namespace as the SKE GUI Service

### DIFF
--- a/ske-gui/templates/ingress.yaml
+++ b/ske-gui/templates/ingress.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ske-gui
+  namespace: kratix-platform-system
   labels:
     {{- include "ske-gui.labels" . | nindent 4 }}
     {{- with .Values.ingress.labels }}


### PR DESCRIPTION
This PR aligns the Ingress manifest to all other manifests for the SKE GUI that need to be deployed under the `kratix-platform-system` namespace.