### PR TITLE
feat: add portalIntegration values block for ske-portal-controller

### DIFF
--- a/.github/workflows/run-ci.yaml
+++ b/.github/workflows/run-ci.yaml
@@ -315,6 +315,9 @@ jobs:
           if [ -n "${{ inputs.update_component }}" ] && [ "${CHART_NAME}" = "ske-operator" ] && [ "${{ inputs.update_component }}" = "backstage-controller" ]; then
             update_script="./scripts/update-ske-operator-backstage-controller"
           fi
+          if [ -n "${{ inputs.update_component }}" ] && [ "${CHART_NAME}" = "ske-operator" ] && [ "${{ inputs.update_component }}" = "ske-portal-controller" ]; then
+            update_script="./scripts/update-ske-operator-portal-controller"
+          fi
 
           echo "Looking for update script in ${update_script}..."
           if [ -f "${update_script}" ]; then
@@ -329,6 +332,9 @@ jobs:
           message="feat(${CHART_NAME}): update appVersion"
           if [ -n "${{ inputs.update_component }}" ] && [ "${CHART_NAME}" = "ske-operator" ] && [ "${{ inputs.update_component }}" = "backstage-controller" ]; then
             message="feat(${CHART_NAME}): update backstage-controller version"
+          fi
+          if [ -n "${{ inputs.update_component }}" ] && [ "${CHART_NAME}" = "ske-operator" ] && [ "${{ inputs.update_component }}" = "ske-portal-controller" ]; then
+            message="feat(${CHART_NAME}): update ske-portal-controller version"
           fi
           if [ "${{ inputs.merge_release_pr }}" == "true" ]; then
             message=$(echo "${message} (autorelease)")

--- a/scripts/update-ske-operator-portal-controller
+++ b/scripts/update-ske-operator-portal-controller
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -euxo pipefail
+
+function main() {
+  root=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )/.." &> /dev/null && pwd )
+
+  # Download the latest Portal Controller release tag
+  latest_release="$(gh release list --repo=syntasso/enterprise-kratix --exclude-pre-releases --order desc --json tagName --jq "[ .[] | select(.tagName | match(\"ske-portal-controller\")) ][0].tagName")"
+  if [ -z "$latest_release" ]; then
+    echo "No release found for ske-portal-controller"
+    exit 1
+  fi
+
+  export latest_version=${latest_release#"ske-portal-controller-"}
+
+  yq -i '.portalIntegration.version = strenv(latest_version)' "${root}/ske-operator/values.yaml"
+}
+
+main

--- a/ske-operator/README.md
+++ b/ske-operator/README.md
@@ -5,3 +5,4 @@ A helm chart for deploying the SKE Operator and other SKE Components including:
 - SKE Platform
 - SKE Cortex Controller
 - SKE Backstage Controller
+- SKE Portal Controller (unified successor to the standalone Cortex/Backstage controllers above; see `portalIntegration` in `values.yaml`)

--- a/ske-operator/templates/portal-integration-deployment-config.yaml
+++ b/ske-operator/templates/portal-integration-deployment-config.yaml
@@ -1,0 +1,30 @@
+{{- if and
+    (hasKey .Values "portalIntegration")
+    (eq (default false .Values.portalIntegration.enabled) true)
+}}
+{{- with .Values.portalIntegration }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: portal-integration-config
+  namespace: kratix-platform-system
+data:
+  portal-integration: |
+    apiVersion: platform.syntasso.io/v1alpha1
+    kind: SKEIntegration
+    metadata:
+      name: portal-integration
+    spec:
+      type: portal-controller
+      version: {{ .version | default "latest" }}
+      {{- with .portals }}
+      portals:
+{{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .deploymentConfig.resources }}
+      deploymentConfig:
+        resources:
+{{- toYaml . | nindent 10 }}
+      {{- end }}
+{{- end }}
+{{- end }}

--- a/ske-operator/templates/post-install-portal-integration.yaml
+++ b/ske-operator/templates/post-install-portal-integration.yaml
@@ -1,0 +1,63 @@
+{{- if and
+    (hasKey .Values "portalIntegration")
+    (eq (default false .Values.portalIntegration.enabled) true)
+}}
+{{- $root := . }}
+{{- with $root.Values.portalIntegration }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: deploy-portal-integration
+  namespace: kratix-platform-system
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "4"
+spec:
+  template:
+    spec:
+      serviceAccountName: ske-operator-controller-manager
+      restartPolicy: Never
+      {{- $pullSecret := (include "ske-operator.effectivePullSecretName" $root | trim) -}}
+      {{- if $pullSecret }}
+      imagePullSecrets:
+        - name: {{ $pullSecret | quote }}
+      {{- end }}
+      containers:
+        - name: deploy-ske
+          image: {{ $root.Values.imageRegistry.host }}/{{ $root.Values.imageRegistry.skeOperatorImage.name }}:{{ $root.Chart.AppVersion }}
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              set -exu
+              kubectl wait --for=condition=KratixDeploymentReady kratixes/kratix --timeout=300s
+              kubectl apply -f /etc/config/portal-integration/portal-integration.yaml
+          volumeMounts:
+            - name: portal-integration-config-volume
+              mountPath: /etc/config/portal-integration
+          resources:
+            requests:
+              cpu: 100m
+              memory: 100Mi
+              ephemeral-storage: 100Mi
+            limits:
+              cpu: 200m
+              memory: 200Mi
+              ephemeral-storage: 200Mi
+      volumes:
+        - name: portal-integration-config-volume
+          configMap:
+            name: portal-integration-config
+            items:
+              - key: portal-integration
+                path: portal-integration.yaml
+      {{- with $root.Values.nodeSelector }}
+      nodeSelector:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with $root.Values.tolerations }}
+      tolerations:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+{{- end -}}
+{{- end -}}

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -271,5 +271,34 @@ cortexIntegration:
     # optional existing Secret reference (used only when token/url are not set)
     # secretRef:
     #   name: "cortex-credentials"
+portalIntegration:
+  # Set to true if you want to deploy the SKE Portal Controller
+  enabled: false
+  # The version of the controller to deploy (moves the bundled adapter image too)
+  version: "latest"
+  deploymentConfig:
+    resources:
+      limits:
+        memory: "256Mi"
+        cpu: "100m"
+      requests:
+        memory: "256Mi"
+        cpu: "100m"
+  # Each entry is passed through verbatim as one SKEIntegration spec.portals[] item — see
+  # ske-operator/docs/skeintegration-portal-controller.md in enterprise-kratix for the full
+  # field reference (name, type, url, secretRef, config, adapterConfig). Freeform by design:
+  # portal types (backstage, cortex, and future ones) each bring their own config shape, so
+  # this chart does not hand-model them.
+  portals: []
+  # Example:
+  # portals:
+  #   - name: prod
+  #     type: backstage
+  #     url: https://backstage.example.com
+  #     secretRef:
+  #       name: backstage-token
+  #     config:
+  #       provider: github
+  #       repositoryName: platform-catalog
 additionalResources: []
 # Any additional k8s resources, such as Secrets, Configmaps

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -229,6 +229,13 @@ skeDeployment:
 #        name: minio-credentials
 #        namespace: default
 
+# backstageIntegration deploys the legacy standalone backstage-controller. New installs
+# should use portalIntegration (below) instead — it deploys the unified ske-portal-controller,
+# which covers Backstage plus other portal types through one controller. backstageIntegration
+# is kept for existing installs and is not removed by enabling portalIntegration; the two can
+# run side by side during migration (they act on disjoint Promise labels). See
+# ske-portal-controller/docs/backstage-migration.md in enterprise-kratix for the field-by-field
+# BackstageEntityCustomization -> PortalCustomization mapping.
 backstageIntegration:
   # Set to true if you want to deploy the SKE Backstage Controller
   enabled: false
@@ -242,6 +249,13 @@ backstageIntegration:
       requests:
         memory: "256Mi"
         cpu: "100m"
+# cortexIntegration deploys the legacy standalone ske-cortex-controller. New installs should
+# use portalIntegration (below) instead — it deploys the unified ske-portal-controller, which
+# covers Cortex plus other portal types through one controller. cortexIntegration is kept for
+# existing installs and is not removed by enabling portalIntegration; the two can run side by
+# side during migration (they act on disjoint Promise labels). See
+# ske-portal-controller/docs/cortex-migration.md in enterprise-kratix for the
+# cortex-config ConfigMap -> portals[].config mapping.
 cortexIntegration:
   # Set to true if you want to deploy the SKE Cortex integration
   enabled: false
@@ -271,6 +285,11 @@ cortexIntegration:
     # optional existing Secret reference (used only when token/url are not set)
     # secretRef:
     #   name: "cortex-credentials"
+# portalIntegration deploys ske-portal-controller, the unified successor to the standalone
+# backstageIntegration/cortexIntegration controllers above (and the install path for any new
+# portal type going forward). Prefer this for new installs. Existing backstageIntegration /
+# cortexIntegration installs are unaffected by enabling this — see the migration notes on
+# those blocks above for moving Promises across.
 portalIntegration:
   # Set to true if you want to deploy the SKE Portal Controller
   enabled: false

--- a/tests/assets/values-with-portal-integration-disabled.yaml
+++ b/tests/assets/values-with-portal-integration-disabled.yaml
@@ -1,0 +1,27 @@
+global:
+  skeOperator:
+    tlsConfig:
+      certManager:
+        disabled: false
+  skeDeployment:
+    deleteOnUninstall: false
+
+skeLicense: "set via cli arg"
+skeDeployment:
+  enabled: true
+  version: "v0.16.0" # older version so we can test upgrade
+  tlsConfig:
+    certManager:
+      disabled: false
+
+portalIntegration:
+  enabled: false
+  version: "latest"
+  deploymentConfig:
+    resources:
+      limits:
+        memory: "512Mi"
+        cpu: "100m"
+      requests:
+        memory: "256Mi"
+        cpu: "400m"

--- a/tests/assets/values-with-portal-integration-enabled.yaml
+++ b/tests/assets/values-with-portal-integration-enabled.yaml
@@ -1,0 +1,45 @@
+global:
+  skeOperator:
+    tlsConfig:
+      certManager:
+        disabled: false
+  skeDeployment:
+    deleteOnUninstall: false
+
+skeLicense: "set via cli arg"
+skeDeployment:
+  enabled: true
+  version: "v0.16.0" # older version so we can test upgrade
+  tlsConfig:
+    certManager:
+      disabled: false
+
+imageRegistry:
+  host: "ghcr.io"
+  skeOperatorImage:
+    name: "syntasso/ske-operator"
+  skePlatformImage:
+    name: "syntasso/ske-platform"
+  skePlatformPipelineAdapterImage:
+    name: "syntasso/ske-platform-pipeline-adapter"
+
+portalIntegration:
+  enabled: true
+  version: "latest"
+  deploymentConfig:
+    resources:
+      limits:
+        memory: "512Mi"
+        cpu: "100m"
+      requests:
+        memory: "256Mi"
+        cpu: "400m"
+  portals:
+    - name: prod
+      type: backstage
+      url: https://backstage.example.com
+      secretRef:
+        name: backstage-token
+      config:
+        provider: github
+        repositoryName: platform-catalog

--- a/tests/ske_operator_test.go
+++ b/tests/ske_operator_test.go
@@ -378,6 +378,51 @@ var _ = Describe("ske-operator helm chart", func() {
 		})
 	})
 
+	Describe("portalIntegration", func() {
+		When("the portalIntegration block is absent", func() {
+			It("does not template the post deploy job or configmap", func() {
+				template, _ := run("helm", "template", "ske-operator", "../ske-operator/", "-f=./assets/values-with-certmanager.yaml")
+				Expect(template).ToNot(ContainSubstring("deploy-portal-integration"))
+				Expect(template).ToNot(ContainSubstring("portal-integration-config"))
+			})
+		})
+
+		When("portalIntegration.enabled is false", func() {
+			It("does not template the post deploy job or configmap", func() {
+				template, _ := run("helm", "template", "ske-operator", "../ske-operator/", "-f=./assets/values-with-portal-integration-disabled.yaml")
+				Expect(template).ToNot(ContainSubstring("deploy-portal-integration"))
+				Expect(template).ToNot(ContainSubstring("portal-integration-config"))
+			})
+		})
+
+		When("portalIntegration.enabled is true", func() {
+			When("templating the chart", func() {
+				It("templates the post deploy job", func() {
+					template, _ := run("helm", "template", "ske-operator", "../ske-operator/", "-s=templates/post-install-portal-integration.yaml", "-f=./assets/values-with-portal-integration-enabled.yaml")
+					Expect(template).To(ContainSubstring("deploy-portal-integration"))
+				})
+
+				It("templates the deployment config job", func() {
+					template, _ := run("helm", "template", "ske-operator", "../ske-operator/", "-s=templates/portal-integration-deployment-config.yaml", "-f=./assets/values-with-portal-integration-enabled.yaml")
+					Expect(template).To(ContainSubstring("portal-integration-config"))
+					Expect(template).To(ContainSubstring("memory: 512Mi"))
+					Expect(template).To(ContainSubstring("cpu: 100m"))
+					Expect(template).To(ContainSubstring("memory: 256Mi"))
+					Expect(template).To(ContainSubstring("cpu: 400m"))
+				})
+
+				It("passes the portals[] entries through into the rendered SKEIntegration", func() {
+					template, _ := run("helm", "template", "ske-operator", "../ske-operator/", "-s=templates/portal-integration-deployment-config.yaml", "-f=./assets/values-with-portal-integration-enabled.yaml")
+					Expect(template).To(ContainSubstring("type: portal-controller"))
+					Expect(template).To(ContainSubstring("name: prod"))
+					Expect(template).To(ContainSubstring("type: backstage"))
+					Expect(template).To(ContainSubstring("repositoryName: platform-catalog"))
+					Expect(template).To(ContainSubstring("name: backstage-token"))
+				})
+			})
+		})
+	})
+
 	Describe("deleteOnUninstall", func() {
 		When("deleteOnUninstall is not set", func() {
 			It("the secret template sets the resource-policy to 'keep'", func() {


### PR DESCRIPTION
## Summary

Adds Helm chart support for the unified `ske-portal-controller` (ADR0009), so it can be enabled the same way `backstageIntegration`/`cortexIntegration` already are. Companion PR in `syntasso/enterprise-kratix`: https://github.com/syntasso/enterprise-kratix/pull/1172

- New `portalIntegration` values block: `enabled`, `version`, `deploymentConfig.resources`, and a freeform `portals[]` passthrough list — not hand-modeled per field, since portal types (Backstage, Cortex, and future ones) each bring their own config shape.
- New `portal-integration-deployment-config.yaml` (renders the `SKEIntegration`) and `post-install-portal-integration.yaml` (the post-install/post-upgrade Job that applies it), mirroring the existing backstage/cortex templates exactly.
- New `update-ske-operator-portal-controller` version-bump script + `run-ci.yaml` wiring for `update_component=ske-portal-controller`.
- Cross-referencing comments added to all three integration blocks in `values.yaml` (+ chart README) so `portalIntegration`'s relationship to the two legacy blocks is discoverable, not just tribal knowledge.

## Test plan

- [x] `helm lint ske-operator` clean.
- [x] `helm template` with `portalIntegration.enabled=true` + a populated `portals[]` list renders a valid `SKEIntegration type: portal-controller`; every field (name, type, url, secretRef, config) round-trips through `toYaml` unmodified — verified by hand and via the new Go test specs.
- [x] `helm template` with the block absent/disabled renders nothing for it.
- [x] `go test -run TestTests -args -ginkgo.focus=portalIntegration` — 5/5 passing specs (disabled/absent renders nothing; enabled renders both the Job and ConfigMap; `portals[]` fields round-trip).
- [x] Live chart install (`helm install` against a real cluster) — not exercised here; existing backstage/cortex `Describe("deploying the chart", ...)` blocks show the pattern if wanted as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)