### PR TITLE
feat(kratix): add support for extra args

### DIFF
--- a/kratix/templates/deployment.yaml
+++ b/kratix/templates/deployment.yaml
@@ -31,6 +31,9 @@ resources:
 {{- $manifest := tpl (.Files.Get "files/deployment.yaml") . | fromYaml }}
 {{- $container := index $manifest.spec.template.spec.containers 0
                     | merge (include "containerPatch" . | fromYaml) }}
+{{- with .Values.extraArgs }}
+{{- $_ := set $container "args" (concat $container.args .) }}
+{{- end }}
 {{- $_ := set $manifest.spec.template "spec"
               (omit $manifest.spec.template.spec "containers") }}
 

--- a/kratix/values.yaml
+++ b/kratix/values.yaml
@@ -4,6 +4,10 @@
 
 image: null
 
+# Additional args appended to the controller-manager container's args,
+# e.g. for flags not otherwise exposed as values (--kube-api-qps, --kube-api-burst, etc.)
+extraArgs: []
+
 resources:
   limits:
     cpu: 100m


### PR DESCRIPTION
This pull request adds support for customising the container arguments in the deployment template by introducing a new `extraArgs` value. This allows users to append additional command-line arguments to the controller-manager container, making it easier to pass flags that are not otherwise configurable.

Configuration enhancements:

* Added a new `extraArgs` field to `values.yaml` to allow users to specify additional arguments for the controller-manager container.
* Updated `deployment.yaml` template to append any specified `extraArgs` to the container's `args` field, enabling more flexible configuration.

This is to support: https://github.com/syntasso/kratix/pull/846