### PR TITLE
feat: reference secrets for SKE Operator webhook

### DIFF
--- a/scripts/update-ske-operator
+++ b/scripts/update-ske-operator
@@ -6,11 +6,24 @@ function generate_resources_without_certmanager(){
   CHART_CRDS_WITHOUT_CERT_MANAGER=$root/ske-operator/charts/ske-operator-crds/templates/crds-without-cert-manager.yaml
   CHART_DIST_WITHOUT_CERT_MANAGER=$root/ske-operator/templates/without-cert-manager.yaml
 
-  echo "{{ if .Values.global.skeOperator.tlsConfig.certManager.disabled }}" > "${CHART_DIST_WITHOUT_CERT_MANAGER}"
+  cat <<'EOF' > "${CHART_DIST_WITHOUT_CERT_MANAGER}"
+{{ if .Values.global.skeOperator.tlsConfig.certManager.disabled }}
+{{- $tlsConfig := .Values.global.skeOperator.tlsConfig }}
+{{- $webhookCABundle := $tlsConfig.webhookCACert | default "" | b64enc }}
+{{- with $tlsConfig.webhookTLSSecretRef }}
+{{- $secretName := required "global.skeOperator.tlsConfig.webhookTLSSecretRef.name is required" .name }}
+{{- $secret := lookup "v1" "Secret" "kratix-platform-system" $secretName }}
+{{- if not $secret }}
+{{- fail (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q was not found in namespace %q" $secretName "kratix-platform-system") }}
+{{- end }}
+{{- $webhookCABundle = required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain ca.crt" $secretName "kratix-platform-system") (dig "data" "ca.crt" "" $secret) }}
+{{- end }}
+EOF
   yq 'select(.kind == "ValidatingWebhookConfiguration")' ${MANIFEST_NAME} |
       yq 'del(.metadata.annotations."cert-manager.io/inject-ca-from")' |
-      yq '.webhooks[0].clientConfig.caBundle= "{{ .Values.global.skeOperator.tlsConfig.webhookCACert | default \"\" | b64enc }}" | .webhooks[0].clientConfig.caBundle style="literal"' >> "${CHART_DIST_WITHOUT_CERT_MANAGER}"
+      yq '.webhooks[].clientConfig.caBundle= "{{ $webhookCABundle }}" | .webhooks[].clientConfig.caBundle style="literal"' >> "${CHART_DIST_WITHOUT_CERT_MANAGER}"
   cat <<EOF >> "${CHART_DIST_WITHOUT_CERT_MANAGER}"
+{{- if not \$tlsConfig.webhookTLSSecretRef }}
 ---
 apiVersion: v1
 data:
@@ -22,15 +35,28 @@ metadata:
   name: ske-operator-webhook-server-cert
   namespace: kratix-platform-system
 type: kubernetes.io/tls
+{{- end }}
 
 EOF
   echo "{{ end }}" >> "${CHART_DIST_WITHOUT_CERT_MANAGER}"
 
 
-  echo "{{ if .Values.global.skeOperator.tlsConfig.certManager.disabled }}" > "${CHART_CRDS_WITHOUT_CERT_MANAGER}"
+  cat <<'EOF' > "${CHART_CRDS_WITHOUT_CERT_MANAGER}"
+{{ if .Values.global.skeOperator.tlsConfig.certManager.disabled }}
+{{- $tlsConfig := .Values.global.skeOperator.tlsConfig }}
+{{- $webhookCABundle := $tlsConfig.webhookCACert | default "" | b64enc }}
+{{- with $tlsConfig.webhookTLSSecretRef }}
+{{- $secretName := required "global.skeOperator.tlsConfig.webhookTLSSecretRef.name is required" .name }}
+{{- $secret := lookup "v1" "Secret" "kratix-platform-system" $secretName }}
+{{- if not $secret }}
+{{- fail (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q was not found in namespace %q" $secretName "kratix-platform-system") }}
+{{- end }}
+{{- $webhookCABundle = required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain ca.crt" $secretName "kratix-platform-system") (dig "data" "ca.crt" "" $secret) }}
+{{- end }}
+EOF
   yq 'select(.kind == "CustomResourceDefinition" and (.spec.conversion // {} | length > 0))' ${MANIFEST_NAME} |
     yq 'del(.metadata.annotations."cert-manager.io/inject-ca-from")' |
-    yq '.spec.conversion.webhook.clientConfig.caBundle= "{{ .Values.global.skeOperator.tlsConfig.webhookCACert | default \"\" | b64enc }}" | .spec.conversion.webhook.clientConfig.caBundle style="literal"' >> "${CHART_CRDS_WITHOUT_CERT_MANAGER}"
+    yq '.spec.conversion.webhook.clientConfig.caBundle= "{{ $webhookCABundle }}" | .spec.conversion.webhook.clientConfig.caBundle style="literal"' >> "${CHART_CRDS_WITHOUT_CERT_MANAGER}"
   echo "---" >> "${CHART_CRDS_WITHOUT_CERT_MANAGER}"
   yq 'select(.kind == "CustomResourceDefinition" and (.spec.conversion // {} | length == 0))' ${MANIFEST_NAME} |
     yq 'del(.metadata.annotations."cert-manager.io/inject-ca-from")' >> "${CHART_CRDS_WITHOUT_CERT_MANAGER}"

--- a/scripts/update-ske-operator
+++ b/scripts/update-ske-operator
@@ -17,6 +17,8 @@ function generate_resources_without_certmanager(){
 {{- fail (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q was not found in namespace %q" $secretName "kratix-platform-system") }}
 {{- end }}
 {{- $webhookCABundle = required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain ca.crt" $secretName "kratix-platform-system") (dig "data" "ca.crt" "" $secret) }}
+{{- $_ := required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain tls.crt" $secretName "kratix-platform-system") (dig "data" "tls.crt" "" $secret) }}
+{{- $_ := required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain tls.key" $secretName "kratix-platform-system") (dig "data" "tls.key" "" $secret) }}
 {{- end }}
 EOF
   yq 'select(.kind == "ValidatingWebhookConfiguration")' ${MANIFEST_NAME} |
@@ -52,6 +54,8 @@ EOF
 {{- fail (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q was not found in namespace %q" $secretName "kratix-platform-system") }}
 {{- end }}
 {{- $webhookCABundle = required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain ca.crt" $secretName "kratix-platform-system") (dig "data" "ca.crt" "" $secret) }}
+{{- $_ := required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain tls.crt" $secretName "kratix-platform-system") (dig "data" "tls.crt" "" $secret) }}
+{{- $_ := required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain tls.key" $secretName "kratix-platform-system") (dig "data" "tls.key" "" $secret) }}
 {{- end }}
 EOF
   yq 'select(.kind == "CustomResourceDefinition" and (.spec.conversion // {} | length > 0))' ${MANIFEST_NAME} |

--- a/ske-operator/charts/ske-operator-crds/templates/crds-without-cert-manager.yaml
+++ b/ske-operator/charts/ske-operator-crds/templates/crds-without-cert-manager.yaml
@@ -8,6 +8,8 @@
 {{- fail (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q was not found in namespace %q" $secretName "kratix-platform-system") }}
 {{- end }}
 {{- $webhookCABundle = required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain ca.crt" $secretName "kratix-platform-system") (dig "data" "ca.crt" "" $secret) }}
+{{- $_ := required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain tls.crt" $secretName "kratix-platform-system") (dig "data" "tls.crt" "" $secret) }}
+{{- $_ := required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain tls.key" $secretName "kratix-platform-system") (dig "data" "tls.key" "" $secret) }}
 {{- end }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/ske-operator/charts/ske-operator-crds/templates/crds-without-cert-manager.yaml
+++ b/ske-operator/charts/ske-operator-crds/templates/crds-without-cert-manager.yaml
@@ -1,4 +1,14 @@
 {{ if .Values.global.skeOperator.tlsConfig.certManager.disabled }}
+{{- $tlsConfig := .Values.global.skeOperator.tlsConfig }}
+{{- $webhookCABundle := $tlsConfig.webhookCACert | default "" | b64enc }}
+{{- with $tlsConfig.webhookTLSSecretRef }}
+{{- $secretName := required "global.skeOperator.tlsConfig.webhookTLSSecretRef.name is required" .name }}
+{{- $secret := lookup "v1" "Secret" "kratix-platform-system" $secretName }}
+{{- if not $secret }}
+{{- fail (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q was not found in namespace %q" $secretName "kratix-platform-system") }}
+{{- end }}
+{{- $webhookCABundle = required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain ca.crt" $secretName "kratix-platform-system") (dig "data" "ca.crt" "" $secret) }}
+{{- end }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -18,7 +28,7 @@ spec:
           namespace: kratix-platform-system
           path: /convert
         caBundle: |-
-          {{ .Values.global.skeOperator.tlsConfig.webhookCACert | default "" | b64enc }}
+          {{ $webhookCABundle }}
       conversionReviewVersions:
         - v1
   group: platform.syntasso.io

--- a/ske-operator/templates/ske-operator-deployment.yaml
+++ b/ske-operator/templates/ske-operator-deployment.yaml
@@ -34,6 +34,17 @@ resources:
 {{- $container := index $manifest.spec.template.spec.containers 0
                     | merge (include "containerPatch" . | fromYaml) }}
 
+{{- if .Values.global.skeOperator.tlsConfig.certManager.disabled }}
+{{- with .Values.global.skeOperator.tlsConfig.webhookTLSSecretRef }}
+{{- $secretName := required "global.skeOperator.tlsConfig.webhookTLSSecretRef.name is required" .name }}
+{{- range $volume := $manifest.spec.template.spec.volumes }}
+{{- if eq $volume.name "cert" }}
+{{- $_ := set $volume.secret "secretName" $secretName }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
 {{- if and (.Values.releaseStorage) (.Values.releaseStorage.customCaCert) (.Values.releaseStorage.customCaCert.name) }}
 {{- $caMountPath := "/tmp/certs/release-storage-ca" }}
 {{- $caVolumeMount := dict "name" "release-storage-ca" "mountPath" $caMountPath "readOnly" true }}

--- a/ske-operator/templates/without-cert-manager.yaml
+++ b/ske-operator/templates/without-cert-manager.yaml
@@ -1,4 +1,14 @@
 {{ if .Values.global.skeOperator.tlsConfig.certManager.disabled }}
+{{- $tlsConfig := .Values.global.skeOperator.tlsConfig }}
+{{- $webhookCABundle := $tlsConfig.webhookCACert | default "" | b64enc }}
+{{- with $tlsConfig.webhookTLSSecretRef }}
+{{- $secretName := required "global.skeOperator.tlsConfig.webhookTLSSecretRef.name is required" .name }}
+{{- $secret := lookup "v1" "Secret" "kratix-platform-system" $secretName }}
+{{- if not $secret }}
+{{- fail (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q was not found in namespace %q" $secretName "kratix-platform-system") }}
+{{- end }}
+{{- $webhookCABundle = required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain ca.crt" $secretName "kratix-platform-system") (dig "data" "ca.crt" "" $secret) }}
+{{- end }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -20,7 +30,7 @@ webhooks:
         namespace: kratix-platform-system
         path: /validate-platform-syntasso-io-v1alpha1-kratix
       caBundle: |-
-        {{ .Values.global.skeOperator.tlsConfig.webhookCACert | default "" | b64enc }}
+        {{ $webhookCABundle }}
     failurePolicy: Fail
     name: vkratix.kb.io
     rules:
@@ -41,6 +51,8 @@ webhooks:
         name: ske-operator-webhook-service
         namespace: kratix-platform-system
         path: /validate-platform-syntasso-io-v1alpha1-skeintegration
+      caBundle: |-
+        {{ $webhookCABundle }}
     failurePolicy: Fail
     name: vskeintegration-v1alpha1.kb.io
     rules:
@@ -54,6 +66,7 @@ webhooks:
         resources:
           - skeintegrations
     sideEffects: None
+{{- if not $tlsConfig.webhookTLSSecretRef }}
 ---
 apiVersion: v1
 data:
@@ -65,5 +78,6 @@ metadata:
   name: ske-operator-webhook-server-cert
   namespace: kratix-platform-system
 type: kubernetes.io/tls
+{{- end }}
 
 {{ end }}

--- a/ske-operator/templates/without-cert-manager.yaml
+++ b/ske-operator/templates/without-cert-manager.yaml
@@ -8,6 +8,8 @@
 {{- fail (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q was not found in namespace %q" $secretName "kratix-platform-system") }}
 {{- end }}
 {{- $webhookCABundle = required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain ca.crt" $secretName "kratix-platform-system") (dig "data" "ca.crt" "" $secret) }}
+{{- $_ := required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain tls.crt" $secretName "kratix-platform-system") (dig "data" "tls.crt" "" $secret) }}
+{{- $_ := required (printf "global.skeOperator.tlsConfig.webhookTLSSecretRef: Secret %q in namespace %q must contain tls.key" $secretName "kratix-platform-system") (dig "data" "tls.key" "" $secret) }}
 {{- end }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -16,10 +16,14 @@ global:
       # issuerRef:
       #   kind: ClusterIssuer
       #   name: custom-selfsigned-issuer
-    # if certManager.disabled is set to true, the following values are required
-    # global.skeOperator.tlsConfig.webhookCACert:
-    # global.skeOperator.tlsConfig.webhookTLSKey:
-    # global.skeOperator.tlsConfig.webhookTLSCert:
+      # if certManager.disabled is set to true, provide either inline cert values or a secretRef.
+      # Inline values (chart creates the Secret from these plaintext values):
+      # webhookCACert:
+      # webhookTLSKey:
+      # webhookTLSCert:
+      # Secret reference (the pre-existing Secret must be in kratix-platform-system and contain ca.crt, tls.crt, and tls.key):
+      # webhookTLSSecretRef:
+      #   name: "my-ske-operator-webhook-tls-secret"
   # skeDeployment:
   # WARNING: when skeDeployment.deleteOnUninstall is true, uninstalling this helm chart will delete your SKE platform
   # only set to true for dev or testing environments

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,3 +1,4 @@
 *.crt
 *.srl
 *.key
+*.test

--- a/tests/assets/example-kratix.yaml
+++ b/tests/assets/example-kratix.yaml
@@ -1,0 +1,6 @@
+apiVersion: platform.syntasso.io/v1alpha1
+kind: Kratix
+metadata:
+  name: kratix
+spec:
+  version: latest

--- a/tests/assets/example-ske-integration.yaml
+++ b/tests/assets/example-ske-integration.yaml
@@ -1,0 +1,7 @@
+apiVersion: platform.syntasso.io/v1alpha1
+kind: SKEIntegration
+metadata:
+  name: webhook-tls-test
+spec:
+  type: backstage
+  version: latest

--- a/tests/ske-operator/tls-tests.bats
+++ b/tests/ske-operator/tls-tests.bats
@@ -2,6 +2,35 @@
 
 load helpers
 
+@test "SKE Operator certManager disabled: inline TLS values populate all webhook CA bundles" {
+  run helm_ske_operator \
+    --set global.skeOperator.tlsConfig.certManager.disabled=true \
+    --set-string global.skeOperator.tlsConfig.webhookCACert=ca \
+    --set-string global.skeOperator.tlsConfig.webhookTLSCert=cert \
+    --set-string global.skeOperator.tlsConfig.webhookTLSKey=key
+  [ "$status" -eq 0 ]
+
+  local webhook_ca_bundles
+  webhook_ca_bundles=$(printf '%s\n' "$output" | yq 'select(.kind == "ValidatingWebhookConfiguration") | .webhooks[].clientConfig.caBundle')
+  [[ "$webhook_ca_bundles" == $'Y2E=\nY2E=' ]]
+
+  local conversion_ca_bundle
+  conversion_ca_bundle=$(printf '%s\n' "$output" | yq 'select(.kind == "CustomResourceDefinition" and .metadata.name == "kratixes.platform.syntasso.io") | .spec.conversion.webhook.clientConfig.caBundle')
+  [[ "$conversion_ca_bundle" == "Y2E=" ]]
+
+  local operator_tls_secret
+  operator_tls_secret=$(printf '%s\n' "$output" | yq 'select(.kind == "Secret" and .metadata.name == "ske-operator-webhook-server-cert") | .metadata.name')
+  [[ "$operator_tls_secret" == "ske-operator-webhook-server-cert" ]]
+}
+
+@test "SKE Operator webhookTLSSecretRef: reports a missing pre-existing Secret" {
+  run helm_ske_operator \
+    --set global.skeOperator.tlsConfig.certManager.disabled=true \
+    --set global.skeOperator.tlsConfig.webhookTLSSecretRef.name=missing-ske-operator-webhook-tls
+  [ "$status" -ne 0 ]
+  [[ "$output" == *'Secret "missing-ske-operator-webhook-tls" was not found in namespace "kratix-platform-system"'* ]]
+}
+
 @test "certManager disabled: both TLS secrets rendered when no secretRefs set" {
   run helm_ske_operator \
     --set skeDeployment.tlsConfig.certManager.disabled=true \

--- a/tests/ske_operator_test.go
+++ b/tests/ske_operator_test.go
@@ -274,6 +274,37 @@ var _ = Describe("ske-operator helm chart", func() {
 			deleteCRDs(context)
 		})
 
+		It("rejects a referenced Secret missing a TLS certificate or private key", func() {
+			run("kubectl", context, "create", "namespace", "kratix-platform-system")
+
+			assertMissingKeyRejected := func(missingKey string, secretArgs ...string) {
+				secretName := "incomplete-ske-operator-webhook-tls"
+				args := []string{context, "create", "secret", "generic", secretName, "-n=kratix-platform-system"}
+				args = append(args, secretArgs...)
+				run(append([]string{"kubectl"}, args...)...)
+
+				command := exec.Command("helm", "install", "ske-operator", "../ske-operator/",
+					"--kube-context=kind-platform",
+					"-n=kratix-platform-system", "-f=./assets/values-without-certmanager.yaml",
+					"--set-string", "skeLicense="+skeLicenseToken,
+					"--set", "skeDeployment.enabled=false",
+					"--set", "global.skeOperator.tlsConfig.webhookTLSSecretRef.name="+secretName,
+					"--dry-run=server")
+				output, err := command.CombinedOutput()
+				Expect(err).To(HaveOccurred())
+				Expect(string(output)).To(ContainSubstring("must contain " + missingKey))
+
+				run("kubectl", context, "delete", "secret", secretName, "-n=kratix-platform-system")
+			}
+
+			assertMissingKeyRejected("tls.crt",
+				"--from-file=ca.crt=./operator-ca.crt",
+				"--from-file=tls.key=./operator-tls.key")
+			assertMissingKeyRejected("tls.key",
+				"--from-file=ca.crt=./operator-ca.crt",
+				"--from-file=tls.crt=./operator-tls.crt")
+		})
+
 		It("uses the referenced Secret for the operator webhook", func() {
 			By("installing only the operator with a pre-existing TLS Secret", func() {
 				run("kubectl", context, "create", "namespace", "kratix-platform-system")

--- a/tests/ske_operator_test.go
+++ b/tests/ske_operator_test.go
@@ -261,6 +261,65 @@ var _ = Describe("ske-operator helm chart", func() {
 		})
 	})
 
+	When("global.skeOperator.tlsConfig.certManager.disabled=true, and a pre-existing operator TLS Secret is provided", func() {
+		BeforeEach(func() {
+			crds, _ := run("kubectl", context, "get", "crds")
+			Expect(crds).NotTo(ContainSubstring("cert-manager"))
+			run("./assets/generate-certs")
+		})
+
+		AfterEach(func() {
+			runLongTimeout("helm", "uninstall", "ske-operator", "-n=kratix-platform-system", "--wait", "--ignore-not-found")
+			runLongTimeout("kubectl", context, "delete", "namespace", "kratix-platform-system", "--timeout="+formatTimeout(kubectlLongTimeout), "--ignore-not-found")
+			deleteCRDs(context)
+		})
+
+		It("uses the referenced Secret for the operator webhook", func() {
+			By("installing only the operator with a pre-existing TLS Secret", func() {
+				run("kubectl", context, "create", "namespace", "kratix-platform-system")
+				run("kubectl", context, "create", "secret", "generic", "example-ske-operator-webhook-tls",
+					"-n=kratix-platform-system", "--type=kubernetes.io/tls",
+					"--from-file=ca.crt=./operator-ca.crt",
+					"--from-file=tls.crt=./operator-tls.crt",
+					"--from-file=tls.key=./operator-tls.key")
+
+				runLongTimeout("helm", "install", "ske-operator", "../ske-operator/",
+					"-n=kratix-platform-system", "-f=./assets/values-without-certmanager.yaml",
+					"--set-string", "skeLicense="+skeLicenseToken,
+					"--set", "skeDeployment.enabled=false",
+					"--set", "global.skeOperator.tlsConfig.webhookTLSSecretRef.name=example-ske-operator-webhook-tls",
+					"--wait", "--timeout=9m")
+			})
+
+			By("verifying the referenced Secret and CA bundle are used", func() {
+				secretName, _ := run("kubectl", context, "get", "deployment", "ske-operator-controller-manager",
+					"-n=kratix-platform-system", `-o=jsonpath={.spec.template.spec.volumes[?(@.name=="cert")].secret.secretName}`)
+				Expect(secretName).To(Equal("example-ske-operator-webhook-tls"))
+
+				generatedSecret, _ := run("kubectl", context, "get", "secret", "ske-operator-webhook-server-cert",
+					"-n=kratix-platform-system", "--ignore-not-found", "-o=name")
+				Expect(generatedSecret).To(BeEmpty())
+
+				secretCABundle, _ := run("kubectl", context, "get", "secret", "example-ske-operator-webhook-tls",
+					"-n=kratix-platform-system", `-o=jsonpath={.data.ca\.crt}`)
+				for _, webhookIndex := range []string{"0", "1"} {
+					webhookCABundle, _ := run("kubectl", context, "get", "validatingwebhookconfiguration", "ske-operator-validating-webhook-configuration",
+						"-o=jsonpath={.webhooks["+webhookIndex+"].clientConfig.caBundle}")
+					Expect(webhookCABundle).To(Equal(secretCABundle))
+				}
+
+				conversionCABundle, _ := run("kubectl", context, "get", "crd", "kratixes.platform.syntasso.io",
+					`-o=jsonpath={.spec.conversion.webhook.clientConfig.caBundle}`)
+				Expect(conversionCABundle).To(Equal(secretCABundle))
+			})
+
+			By("validating resources through both operator webhooks", func() {
+				run("kubectl", context, "apply", "--dry-run=server", "-f=assets/example-kratix.yaml")
+				run("kubectl", context, "apply", "--dry-run=server", "-f=assets/example-ske-integration.yaml")
+			})
+		})
+	})
+
 	Describe("backstageIntegration", func() {
 		When("the backstageIntegration block is absent", func() {
 			It("does not template the post deploy job or configmap", func() {

--- a/values.yaml
+++ b/values.yaml
@@ -16,10 +16,14 @@ global:
       # issuerRef:
       #   kind: ClusterIssuer
       #   name: custom-selfsigned-issuer
-    # if certManager.disabled is set to true, the following values are required
-    # global.skeOperator.tlsConfig.webhookCACert:
-    # global.skeOperator.tlsConfig.webhookTLSKey:
-    # global.skeOperator.tlsConfig.webhookTLSCert:
+      # if certManager.disabled is set to true, provide either inline cert values or a secretRef.
+      # Inline values (chart creates the Secret from these plaintext values):
+      # webhookCACert:
+      # webhookTLSKey:
+      # webhookTLSCert:
+      # Secret reference (the pre-existing Secret must be in kratix-platform-system and contain ca.crt, tls.crt, and tls.key):
+      # webhookTLSSecretRef:
+      #   name: "my-ske-operator-webhook-tls-secret"
   # skeDeployment:
   # WARNING: when skeDeployment.deleteOnUninstall is true, uninstalling this helm chart will delete your SKE platform
   # only set to true for dev or testing environments


### PR DESCRIPTION
This change makes it possible to use existing `Secret`s to provide TLS certificates to the SKE Operator webhooks.

Closes #205 