### PR TITLE
feat(ske-operator): allow overriding the portal-controller images via imageRegistry

### DIFF
--- a/ske-operator/templates/operator-config.yaml
+++ b/ske-operator/templates/operator-config.yaml
@@ -37,6 +37,8 @@ data:
       pipelineImage: {{ .skePlatformPipelineAdapterImage.name }}
       backstageControllerImage: {{ .backstageControllerImage.name }}
       cortexControllerImage: {{ .cortexControllerImage.name }}
+      portalControllerImage: {{ .portalControllerImage.name }}
+      portalAdapterImage: {{ .portalAdapterImage.name }}
     {{- end }}
 
 {{ if and (.Values.releaseStorage) (.Values.releaseStorage.git) (.Values.releaseStorage.git.secret) (.Values.releaseStorage.git.secret.values) }}

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -86,6 +86,15 @@ imageRegistry:
   cortexControllerImage:
     # The name of the Cortex Controller image
     name: "syntasso/ske-cortex-controller"
+  portalControllerImage:
+    # The name of the SKE Portal Controller image
+    name: "syntasso/ske-portal-controller"
+  portalAdapterImage:
+    # The name of the portal adapter image. The adapter is a second entrypoint in the
+    # Portal Controller image, so this normally matches portalControllerImage; set it
+    # only to point every portal connection at a different adapter build.
+    # Individual connections can override it via portalIntegration.portals[].adapterConfig.image.
+    name: "syntasso/ske-portal-controller"
 # Syntasso Enterprise manifests are available in the S3 bucket below
 # If you are using a custom bucket, update the values accordingly
 releaseStorage:

--- a/tests/ske_operator_test.go
+++ b/tests/ske_operator_test.go
@@ -509,6 +509,22 @@ var _ = Describe("ske-operator helm chart", func() {
 					Expect(template).To(ContainSubstring("repositoryName: platform-catalog"))
 					Expect(template).To(ContainSubstring("name: backstage-token"))
 				})
+
+				It("templates the default portal images in the Operator Config", func() {
+					template, _ := run("helm", "template", "ske-operator", "../ske-operator/", "-s=templates/operator-config.yaml", "-f=./assets/values-with-portal-integration-enabled.yaml")
+					Expect(template).To(ContainSubstring("portalControllerImage: syntasso/ske-portal-controller"))
+					Expect(template).To(ContainSubstring("portalAdapterImage: syntasso/ske-portal-controller"))
+				})
+
+				When("specifying custom portal images", func() {
+					It("templates the imageRegistry portal images in the Operator Config", func() {
+						template, _ := run("helm", "template", "ske-operator", "../ske-operator/", "-s=templates/operator-config.yaml", "-f=./assets/values-with-portal-integration-enabled.yaml",
+							"--set=imageRegistry.portalControllerImage.name=my-path/portal-controller",
+							"--set=imageRegistry.portalAdapterImage.name=my-path/portal-adapter")
+						Expect(template).To(ContainSubstring("portalControllerImage: my-path/portal-controller"))
+						Expect(template).To(ContainSubstring("portalAdapterImage: my-path/portal-adapter"))
+					})
+				})
 			})
 		})
 	})


### PR DESCRIPTION
## Why

`backstageControllerImage` and `cortexControllerImage` are plumbed from `values.yaml` into the `ske-operator` ConfigMap, but the portal equivalents never were. The operator has expected both keys since portal-controller install landed:

- `ske-operator/api/v1alpha1/config.go:81-82` — `portalControllerImage`, `portalAdapterImage`
- `internal/controller/reconcile_objects.go:575-578` — uses them to set the manager image and `PORTAL_ADAPTER_IMG`

It isn't fatal today because `reconcile_release.go:71-72` falls back to the `syntasso/ske-portal-controller` defaults. But an install mirroring images to a private registry under a different path had no way to point `portalIntegration` at them, unlike the other two integrations.

## What changed

- `imageRegistry.portalControllerImage.name` and `imageRegistry.portalAdapterImage.name` in `ske-operator/values.yaml`, both defaulting to `syntasso/ske-portal-controller`.
- Both emitted in `templates/operator-config.yaml`.

`portalAdapterImage` is exposed alongside the controller image because the adapter is a second entrypoint in the *same* image. Overriding only the controller image would leave the adapter resolving to the un-mirrored default. Per-connection overrides via `portalIntegration.portals[].adapterConfig.image` are unaffected.

## Verification

Two specs added to `tests/ske_operator_test.go`, mirroring the existing `cortexControllerImage` one: defaults render, and `--set imageRegistry.portal*Image.name=...` overrides render.

I confirmed the specs bite — with the two template lines removed both fail, while the cortex spec still passes:

```
Ran 3 of 30 Specs
FAIL! -- 1 Passed | 2 Failed
```

With the change in place, the full template-only suite is green (`Ran 14 of 30 Specs ... 14 Passed | 0 Failed`). The remaining 16 need a kind cluster and a real `SKE_LICENSE_TOKEN`, so CI covers those.

The rendered keys match the operator's JSON tags exactly, verified against `config.go`.

## Context

Companion to syntasso/enterprise-kratix#1307, which fixes the `ske-portal-controller` release pipeline. This PR should land **before** the first successful portal release, because `create-release.yaml` dispatches `update_component=ske-portal-controller` on success.

Note: the chart's `portalIntegration` block, templates and update script already exist on `main` — this only adds the image-override keys.

Not addressed here: the repo-root `values.yaml` aggregate reference file is unreferenced by any script and has drifted much further (it has no `portalIntegration` at all). Reconciling it is its own change.