### PR TITLE
test(ske-operator): allow for GC tail latency when asserting Kratix teardown

### DIFF
--- a/tests/ske_operator_test.go
+++ b/tests/ske_operator_test.go
@@ -25,6 +25,11 @@ var (
 	kubectlLongTimeout        = time.Second * 300
 	certManagerWebhookTimeout = time.Second * 300
 
+	// Uninstalling with deleteOnUninstall removes the CRDs, so the Kratix Deployment is left to
+	// Kubernetes' garbage collector as a dependent whose owner's CRD is gone. That collection is
+	// discovery-driven, so its tail latency is far longer than a normal owner-triggered delete.
+	gcTimeout = time.Second * 300
+
 	context = "--context=kind-platform"
 )
 
@@ -602,7 +607,7 @@ var _ = Describe("ske-operator helm chart", func() {
 						Eventually(func() string {
 							out, _ := run("kubectl", context, "get", "deployments", "kratix-platform-controller-manager", "-n=kratix-platform-system", "--ignore-not-found")
 							return out
-						}, timeout, interval).Should(BeEmpty())
+						}, gcTimeout, interval).Should(BeEmpty())
 					})
 
 					By("deleting the crds", func() { // if the crds are deleted, so are the Kratix custom resources


### PR DESCRIPTION
## Why

`deleteOnUninstall … uninstalls the deployed kratix when uninstalling the ske operator` flakes roughly 2 in 6 runs, and it has now cost two `ske-operator` chart-version updates ([30564149043](https://github.com/syntasso/helm-charts/actions/runs/30564149043), [30566544508](https://github.com/syntasso/helm-charts/actions/runs/30566544508)). The `test` job fails, so `update-and-release` is skipped and `appVersion` never gets bumped.

It's a flake, not a regression — the same commit `9e28fa12` both passes and fails (17:26 pass, 17:34 fail, 17:41 pass).

## What it's waiting on

The assertion polls for `kratix-platform-controller-manager` to disappear. That Deployment is owned by the `Kratix` CR (`ske-operator/internal/controller/reconcile_objects.go:297`), and with `deleteOnUninstall: true` the CRDs are deleted on uninstall, so the CR vanishes and the Deployment is left to Kubernetes' garbage collector as a dependent whose owner's CRD is gone.

That collection path is discovery-driven, so its tail latency is much longer than a normal owner-triggered delete — unlike the sibling `deleting operator` assertion, which waits on a Deployment Helm removes directly and doesn't flake.

## What changed

The assertion's deadline goes from `timeout` (100s) to a new `gcTimeout` (300s). A dedicated constant rather than reusing `kubectlLongTimeout`, since that one is for `kubectl --timeout` values and this is an `Eventually` deadline; the constant carries the explanation.

Deliberately **not** `longTimeout` (1200s) — if teardown ever genuinely hangs, this should still fail in minutes rather than twenty.

Scoped to the one assertion. The sibling `deleting operator` check keeps `timeout`, since it isn't affected.

## What this does and does not fix

It stops the flake blocking releases. It does **not** address the underlying behaviour: nothing in the chart actually deletes the Kratix Deployment, so a user running `helm uninstall` with `deleteOnUninstall: true` can be left with an orphaned `kratix-platform-controller-manager` still running.

That's filed as #214, with the proposed `pre-delete` hook fix and the groundwork already verified (gate expression, RBAC, template to mirror). The observed failures are consistent with tail latency rather than a hard hang — the Deployment usually is collected within 100s — which is what makes a deadline bump a legitimate interim measure rather than hiding a break.

Worth being explicit that the mechanism is a strong hypothesis, not proven: the competing explanation is that CRD deletion itself stalls. #214 covers adding the diagnostics needed to tell them apart.

## Verification

`gofmt` clean, `go vet ./...` passes. The real check is this PR's own `test` job — it runs the full 30-spec suite including the flaky spec, now with the wider deadline.