### PR TITLE
feat(ske-operator): expose featureFlags config in the ske-operator chart

### DIFF
--- a/ske-operator/templates/ske-deployment-config.yaml
+++ b/ske-operator/templates/ske-deployment-config.yaml
@@ -13,6 +13,10 @@ data:
       name: kratix
     spec:
       version: {{ .version | default "latest" }}
+{{- with .featureFlags }}
+      featureFlags:
+{{- toYaml . | nindent 8 }}
+{{- end }}
 {{- with .webhookConfig }}
       webhookConfig:
 {{- toYaml . | nindent 8 }}

--- a/ske-operator/values.yaml
+++ b/ske-operator/values.yaml
@@ -158,6 +158,17 @@ skeDeployment:
   enabled: true
   # The version of ske to deploy
   version: "latest"
+  # Opt in to preview features on the deployed SKE platform. Each entry is passed
+  # through verbatim as one Kratix spec.featureFlags key, so a flag added by a newer
+  # SKE release needs no chart change; the Kratix CRD is what validates the names.
+  # Every flag here is a PREVIEW feature: not production ready, off unless set, and
+  # subject to change or removal in any release. Flags also require an SKE version
+  # that supports them — the operator webhook rejects the combination otherwise.
+  featureFlags: {}
+  # featureFlags:
+  #   # Gates the DryRun controller and the dryruns CRD. Setting this to false again
+  #   # disables the feature but leaves the CRD in place.
+  #   dryRun: true
   deploymentConfig:
     resources:
       limits:

--- a/tests/ske-operator/feature-flags-tests.bats
+++ b/tests/ske-operator/feature-flags-tests.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "featureFlags: not rendered by default" {
+  run helm_ske_operator
+  [ "$status" -eq 0 ]
+
+  local deployment_config
+  deployment_config="$(ske_deployment_config "$output")"
+
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.featureFlags') == "null" ]]
+}
+
+@test "featureFlags: dryRun rendered when set" {
+  run helm_ske_operator \
+    --set 'skeDeployment.featureFlags.dryRun=true'
+  [ "$status" -eq 0 ]
+
+  local deployment_config
+  deployment_config="$(ske_deployment_config "$output")"
+
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.featureFlags.dryRun') == "true" ]]
+}
+
+@test "featureFlags: passed through verbatim so new flags need no chart change" {
+  run helm_ske_operator \
+    --set 'skeDeployment.featureFlags.dryRun=false' \
+    --set 'skeDeployment.featureFlags.someFutureFlag=true'
+  [ "$status" -eq 0 ]
+
+  local deployment_config
+  deployment_config="$(ske_deployment_config "$output")"
+
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.featureFlags.dryRun') == "false" ]]
+  [[ $(printf '%s\n' "$deployment_config" | yq '.spec.featureFlags.someFutureFlag') == "true" ]]
+}


### PR DESCRIPTION
Refs syntasso/enterprise-kratix#1318

## What

Adds `skeDeployment.featureFlags` to the ske-operator chart and renders it into
the `Kratix` spec in the `ske-deployment-config` ConfigMap:

```yaml
skeDeployment:
  featureFlags:
    dryRun: true
```

```yaml
# rendered
spec:
  version: latest
  featureFlags:
    dryRun: true
```

## Why

Kratix is gaining preview features gated by `spec.featureFlags` on the `Kratix`
CRD, starting with `dryRun`. The chart had no way to set them, so the only route
was editing the `ske-deployment` ConfigMap out of band.

## Design decision: freeform passthrough, not hand-modelled flags

The block is passed through with `toYaml` rather than modelling `dryRun`
explicitly, so a flag added by a newer SKE release needs no chart change and the
`Kratix` CRD stays the single validator of flag names. This mirrors how the chart
already handles `webhookConfig` and `portalIntegration.portals`.

There is a test that locks this in — it sets a second, made-up flag alongside
`dryRun` and asserts both survive, so narrowing the template back to a
hand-modelled `dryRun` fails CI.

## Scope

Chart-side only, which is the part of #1318 that lives in this repo. The operator
work the issue describes — the `FeatureFlags` API type, merging into the `kratix`
ConfigMap without clobbering sibling keys, rolling the controller-manager,
filtering the `dryruns` CRD, and the version gate in the webhook — all lands in
`enterprise-kratix`. This chart just needs to be able to express the field.

Two deliberate non-changes:

- **Root `values.yaml` is untouched.** It is an abridged example that already
  omits `webhookConfig`, `platformManagerDeploymentConfig`, `volumes` and more;
  `featureFlags` belongs with them.
- **No default flag values.** `featureFlags: {}` ships empty and `with` skips an
  empty block, so charts that do not opt in render no `featureFlags` key at all.

The `values.yaml` comment carries the preview framing from the issue: not
production ready, off unless set, and requires an SKE version that supports the
flag.

## Tests

`tests/ske-operator/feature-flags-tests.bats` — 3 tests, TDD'd:

| Test | Asserts |
| --- | --- |
| not rendered by default | no `spec.featureFlags` key with no opt-in |
| dryRun rendered when set | `spec.featureFlags.dryRun: true` |
| passed through verbatim | an unknown flag reaches the spec alongside `dryRun` |

Each was mutation-checked — the template was temporarily broken (rendering
unconditionally, and narrowing to `dryRun`-only) to confirm the tests actually
fail rather than passing vacuously.

`bats tests/ske-operator/` — 46 passing, 0 failures (43 before this change).
The ginkgo suite needs a Kind cluster and licensed images, so it was not run
locally; CI covers it.

Co-authored-by: Derik Evangelista <derik@syntasso.io>
Co-authored-by: Chunyi Lyu <chunyi@syntasso.io>

🤖 Generated with [Claude Code](https://claude.com/claude-code)